### PR TITLE
Fallback to local env vars when AWS credentials are not found

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,8 @@ libraryDependencies ++= Seq(
     exclude("org.slf4j", "slf4j-log4j12"),
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",
   "com.geteventstore" %% "eventstore-client" % "3.0.4",
-  "org.apache.activemq" % "activemq-client" % "5.14.2"
+  "org.apache.activemq" % "activemq-client" % "5.14.2",
+  "com.typesafe" % "config" % "1.3.1"
 )
 
 assemblyOption in assembly ~= { _.copy(includeBin = true, includeScala = false, includeDependency = false) }

--- a/src/main/scala/com/softwaremill/mqperf/DynamoResultsTable.scala
+++ b/src/main/scala/com/softwaremill/mqperf/DynamoResultsTable.scala
@@ -1,17 +1,22 @@
 package com.softwaremill.mqperf
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
-import com.softwaremill.mqperf.config.AWSCredentialsFromEnv
-import com.amazonaws.regions.{Regions, Region}
+import com.softwaremill.mqperf.config.{AWSCredentialsFromEnv, TestConfigOnS3}
+import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.dynamodbv2.model.{DeleteItemRequest, ScanRequest}
+
 import scala.collection.JavaConversions._
 
 trait DynamoResultsTable {
-  protected val dynamoClient = {
-    val c = new AmazonDynamoDBClient(AWSCredentialsFromEnv())
-    c.setRegion(Region.getRegion(Regions.EU_WEST_1))
-    c
-  }
+  protected val dynamoClientOpt: Option[AmazonDynamoDBClient] =
+    for {
+      awsCredentails <- AWSCredentialsFromEnv(TestConfigOnS3.LocalConfig)
+    } yield {
+      val c = new AmazonDynamoDBClient()
+      c.setRegion(Region.getRegion(Regions.EU_WEST_1))
+      c
+    }
+
   protected val tableName = "mqperf-results"
 
   protected val resultNameColumn = "test_result_name"
@@ -26,8 +31,14 @@ trait DynamoResultsTable {
 }
 
 object ClearDynamoResultsTable extends App with DynamoResultsTable {
-  dynamoClient.scan(new ScanRequest(tableName)).getItems.foreach { i =>
-    dynamoClient.deleteItem(
-      new DeleteItemRequest().withTableName(tableName).addKeyEntry(resultNameColumn, i.get(resultNameColumn)))
+
+  for {
+    dynamoClient <- dynamoClientOpt
+  } {
+    dynamoClient.scan(new ScanRequest(tableName)).getItems.foreach { i =>
+      dynamoClient.deleteItem(
+        new DeleteItemRequest().withTableName(tableName).addKeyEntry(resultNameColumn, i.get(resultNameColumn)))
+    }
   }
+
 }

--- a/src/main/scala/com/softwaremill/mqperf/DynamoResultsTable.scala
+++ b/src/main/scala/com/softwaremill/mqperf/DynamoResultsTable.scala
@@ -12,7 +12,7 @@ trait DynamoResultsTable {
     for {
       awsCredentails <- AWSCredentialsFromEnv(TestConfigOnS3.LocalConfig)
     } yield {
-      val c = new AmazonDynamoDBClient()
+      val c = new AmazonDynamoDBClient(awsCredentails)
       c.setRegion(Region.getRegion(Regions.EU_WEST_1))
       c
     }

--- a/src/main/scala/com/softwaremill/mqperf/Receiver.scala
+++ b/src/main/scala/com/softwaremill/mqperf/Receiver.scala
@@ -27,19 +27,18 @@ object Receiver extends App {
   }
 }
 
-class ReceiverRunnable(
-  mq: Mq,
-  reportResults: ReportResults,
-  receiveMsgBatchSize: Int) extends Runnable {
+class ReceiverRunnable(mq: Mq,
+                       reportResults: ReportResults,
+                       receiveMsgBatchSize: Int) extends Runnable {
 
-  override def run() = {
+  override def run(): Unit = {
     val mqReceiver = mq.createReceiver()
 
     val start = System.currentTimeMillis()
     var lastReceived = System.currentTimeMillis()
     var totalReceived = 0
 
-    while ((System.currentTimeMillis() - lastReceived) < 60*1000L) {
+    while ((System.currentTimeMillis() - lastReceived) < 60 * 1000L) {
       val received = doReceive(mqReceiver)
 
       if (received > 0) {
@@ -56,7 +55,7 @@ class ReceiverRunnable(
   private def doReceive(mqReceiver: mq.MqReceiver) = {
     val msgs = mqReceiver.receive(receiveMsgBatchSize)
     val ids = msgs.map(_._1)
-    if (ids.size > 0) {
+    if (ids.nonEmpty) {
       mqReceiver.ack(ids)
     }
 

--- a/src/main/scala/com/softwaremill/mqperf/ReportResults.scala
+++ b/src/main/scala/com/softwaremill/mqperf/ReportResults.scala
@@ -23,25 +23,29 @@ class ReportResults(testConfigName: String) extends DynamoResultsTable {
   }
 
   private def doReport(start: Long, end: Long, msgsCount: Int, _type: String) {
-    val df = newDateFormat
+    for {
+      dynamoClient <- dynamoClientOpt
+    } {
+      val df = newDateFormat
 
-    val testResultName = s"$testConfigName-${_type}-${Random.nextInt(100000)}"
-    val took = (end - start).toString
-    val startStr = new Date(start)
-    val endStr = new Date(end)
+      val testResultName = s"$testConfigName-${_type}-${Random.nextInt(100000)}"
+      val took = (end - start).toString
+      val startStr = new Date(start)
+      val endStr = new Date(end)
 
-    dynamoClient.putItem(new PutItemRequest()
-      .withTableName(tableName)
-      .addItemEntry(resultNameColumn, new AttributeValue(testResultName))
-      .addItemEntry(msgsCountColumn, new AttributeValue().withN(msgsCount.toString))
-      .addItemEntry(tookColumn, new AttributeValue().withN(took))
-      .addItemEntry(startColumn, new AttributeValue(df.format(startStr)))
-      .addItemEntry(endColumn, new AttributeValue(df.format(endStr)))
-      .addItemEntry(typeColumn, new AttributeValue(_type))
-    )
+      dynamoClient.putItem(new PutItemRequest()
+        .withTableName(tableName)
+        .addItemEntry(resultNameColumn, new AttributeValue(testResultName))
+        .addItemEntry(msgsCountColumn, new AttributeValue().withN(msgsCount.toString))
+        .addItemEntry(tookColumn, new AttributeValue().withN(took))
+        .addItemEntry(startColumn, new AttributeValue(df.format(startStr)))
+        .addItemEntry(endColumn, new AttributeValue(df.format(endStr)))
+        .addItemEntry(typeColumn, new AttributeValue(_type))
+      )
 
-    println("Wrote to dynamo")
-    println(s"$testResultName (${_type}, ${msgsCount.toString}): $took ($startStr -> $endStr")
+      println("Wrote to dynamo")
+      println(s"$testResultName (${_type}, ${msgsCount.toString}): $took ($startStr -> $endStr")
+    }
   }
 
   private def newDateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss")

--- a/src/main/scala/com/softwaremill/mqperf/config/AWSCredentialsFromEnv.scala
+++ b/src/main/scala/com/softwaremill/mqperf/config/AWSCredentialsFromEnv.scala
@@ -1,6 +1,7 @@
 package com.softwaremill.mqperf.config
 
 import com.amazonaws.auth.BasicAWSCredentials
+import com.typesafe.config.Config
 
 object AWSCredentialsFromEnv {
   def apply() = {
@@ -8,4 +9,11 @@ object AWSCredentialsFromEnv {
       sys.env("AWS_ACCESS_KEY_ID"),
       sys.env("AWS_SECRET_ACCESS_KEY"))
   }
+
+  def apply(config: Config): Option[BasicAWSCredentials] =
+    for {
+      awsKeyId <- config.getStringOpt("AWS_ACCESS_KEY_ID")
+      awsSecretKey <- config.getStringOpt("AWS_SECRET_ACCESS_KEY")
+    } yield new BasicAWSCredentials(awsKeyId, awsSecretKey)
+
 }

--- a/src/main/scala/com/softwaremill/mqperf/config/TestConfigOnS3.scala
+++ b/src/main/scala/com/softwaremill/mqperf/config/TestConfigOnS3.scala
@@ -89,7 +89,7 @@ object TestConfigOnS3 {
 }
 
 object WriteTestConfigOnS3 extends App {
-  if (args.length == 0) {
+  if (args.isEmpty) {
     println("Usage:")
     println("java ... S3TestConfigWriter [testName] [runid]")
     println("where [testName] is name of a file in the tests directory, without the .json suffix")

--- a/src/main/scala/com/softwaremill/mqperf/config/TestConfigOnS3.scala
+++ b/src/main/scala/com/softwaremill/mqperf/config/TestConfigOnS3.scala
@@ -1,71 +1,86 @@
 package com.softwaremill.mqperf.config
 
 import com.amazonaws.services.s3.AmazonS3Client
+
 import scala.io.Source
 import scala.collection.JavaConversions._
 import java.io.{ByteArrayInputStream, File}
-import com.amazonaws.services.s3.model.{ObjectMetadata, CannedAccessControlList, PutObjectRequest}
+
+import com.amazonaws.services.s3.model.{CannedAccessControlList, ObjectMetadata, PutObjectRequest}
+import com.typesafe.config.{Config, ConfigFactory}
 
 class TestConfigOnS3(private val objectName: String) {
-  private val s3Client = new AmazonS3Client(AWSCredentialsFromEnv())
+
+  private val s3ClientOpt: Option[AmazonS3Client] = AWSCredentialsFromEnv(TestConfigOnS3.LocalConfig).map(new AmazonS3Client(_))
   private val bucketName = "mqperf"
   private val whenChangedPollEveryMs = 1000L
 
   def this() = this("test_config.json")
 
-  def read(): String = {
-    val exists = s3Client
-      .listObjects(bucketName, objectName)
-      .getObjectSummaries
-      .filter(_.getKey == objectName)
-      .nonEmpty
-
-    if (exists) {
+  def read(): TestConfig = {
+    val s3ConfigOpt = for {
+      s3Client <- s3ClientOpt
+      if s3Client.listObjects(bucketName, objectName).getObjectSummaries.exists(_.getKey == objectName)
+    } yield {
       val is = s3Client.getObject(bucketName, objectName).getObjectContent
-      Source.fromInputStream(is).getLines().mkString("\n")
-    } else {
-      ""
+      val rawConfig = Source.fromInputStream(is).getLines().mkString("\n")
+      ConfigFactory.parseString(rawConfig)
     }
+    TestConfig.from(s3ConfigOpt.getOrElse(TestConfigOnS3.LocalConfig))
   }
 
-  def lastModified() = {
-    s3Client
-      .listObjects(bucketName, objectName)
-      .getObjectSummaries
-      .filter(_.getKey == objectName)
-      .map(_.getLastModified.getTime)
-      .headOption
-      .getOrElse(0)
-  }
+  def lastModified(): Option[Long] =
+    for {
+      s3Client <- s3ClientOpt
+    } yield {
+      s3Client
+        .listObjects(bucketName, objectName)
+        .getObjectSummaries
+        .find(_.getKey == objectName)
+        .map(_.getLastModified.getTime)
+        .getOrElse(0)
+    }
 
-  def write(file: File, runId: String) {
+  def write(file: File, runId: String): Unit = {
     val content = Source.fromFile(file).getLines().toList
       .map(_.replace("$runid", runId))
 
     val is = new ByteArrayInputStream(content.mkString("\n").getBytes)
 
-    s3Client.putObject(
-      new PutObjectRequest(bucketName, objectName, is, new ObjectMetadata())
-        .withCannedAcl(CannedAccessControlList.PublicRead))
+    for {
+      s3Client <- s3ClientOpt
+    } {
+      s3Client.putObject(
+        new PutObjectRequest(bucketName, objectName, is, new ObjectMetadata())
+          .withCannedAcl(CannedAccessControlList.PublicRead))
+    }
   }
 
   def whenChanged(block: TestConfig => Unit) {
-    var lastMod = lastModified()
-    while (true) {
-      Thread.sleep(whenChangedPollEveryMs)
-      val newMod = lastModified()
-      if (newMod != lastMod) {
-        block(TestConfig.from(read()))
-      }
+    lastModified() match {
+      case Some(lm) =>
+        var lastMod = lastModified()
+        while (true) {
+          Thread.sleep(whenChangedPollEveryMs)
+          val newMod = lastModified()
+          if (newMod != lastMod) {
+            block(read())
+          }
 
-      lastMod = newMod
+          lastMod = newMod
+        }
+      case None =>
+        block(read())
     }
   }
 }
 
 object TestConfigOnS3 {
-  def create(args:Array[String]):TestConfigOnS3 = {
-    if(args.length == 0) {
+
+  val LocalConfig: Config = ConfigFactory.load()
+
+  def create(args: Array[String]): TestConfigOnS3 = {
+    if (args.length == 0) {
       new TestConfigOnS3("test_config.json")
     } else {
       new TestConfigOnS3(args(0))
@@ -74,7 +89,7 @@ object TestConfigOnS3 {
 }
 
 object WriteTestConfigOnS3 extends App {
-  if (args.size == 0) {
+  if (args.length == 0) {
     println("Usage:")
     println("java ... S3TestConfigWriter [testName] [runid]")
     println("where [testName] is name of a file in the tests directory, without the .json suffix")
@@ -83,7 +98,7 @@ object WriteTestConfigOnS3 extends App {
     if (!sourceFile.exists()) {
       println(s"File ${sourceFile.getAbsolutePath} does not exist!")
     } else {
-      val runId = if (args.size >= 2) args(1) else System.currentTimeMillis().toString
+      val runId = if (args.length >= 2) args(1) else System.currentTimeMillis().toString
       new TestConfigOnS3().write(sourceFile, runId)
     }
   }

--- a/src/main/scala/com/softwaremill/mqperf/config/package.scala
+++ b/src/main/scala/com/softwaremill/mqperf/config/package.scala
@@ -1,0 +1,25 @@
+package com.softwaremill.mqperf
+
+import com.typesafe.config.Config
+
+package object config {
+
+  implicit class RichTypesafeConfig(config: Config) {
+
+    def getStringOpt(path: String): Option[String] = getOpt(path, _.getString(_))
+
+    def getIntOpt(path: String): Option[Int] = getOpt(path, _.getInt(_))
+
+    def getConfigOpt(path: String): Option[Config] = getOpt(path, _.getConfig(_))
+
+    def getOpt[T](path: String, block: (Config, String) => T): Option[T] = {
+      if (config.hasPath(path)) {
+        Option(block(config, path))
+      } else {
+        None
+      }
+    }
+
+  }
+
+}

--- a/src/test/scala/com/softwaremill/mqperf/config/TestConfigTest.scala
+++ b/src/test/scala/com/softwaremill/mqperf/config/TestConfigTest.scala
@@ -1,11 +1,12 @@
 package com.softwaremill.mqperf.config
 
-import org.scalatest.{Matchers, FlatSpec}
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{FlatSpec, Matchers}
 
 class TestConfigTest extends FlatSpec with Matchers {
   it should "parse an example json" in {
     // given
-    val json =
+    val config = ConfigFactory.parseString {
       """
         |{
         |    "name": "sqs1",
@@ -18,17 +19,18 @@ class TestConfigTest extends FlatSpec with Matchers {
         |    "receive_msg_batch_size": 25
         |}
       """.stripMargin
+    }
 
     // when
-    val tc = TestConfig.from(json)
+    val tc = TestConfig.from(config)
 
     // then
-    tc should be (TestConfig("sqs1", "Sqs", 10, 100000, 100, 20, 11, 25, Map()))
+    tc should be(TestConfig("sqs1", "Sqs", 10, 100000, 100, 20, 11, 25, Map()))
   }
 
   it should "parse an example json with mq config map" in {
     // given
-    val json =
+    val config = ConfigFactory.parseString {
       """
         |{
         |    "name": "sqs1",
@@ -45,11 +47,12 @@ class TestConfigTest extends FlatSpec with Matchers {
         |    }
         |}
       """.stripMargin
+    }
 
     // when
-    val tc = TestConfig.from(json)
+    val tc = TestConfig.from(config)
 
     // then
-    tc should be (TestConfig("sqs1", "Sqs", 10, 100000, 100, 20, 11, 25, Map("f1" -> "v1", "f2" -> "10")))
+    tc should be(TestConfig("sqs1", "Sqs", 10, 100000, 100, 20, 11, 25, Map("f1" -> "v1", "f2" -> "10")))
   }
 }


### PR DESCRIPTION
When AWS credentials are not defined, we try to load configuration from the local env using typesafe config.

Some of the AWS-specific clients are now marked as optional, especially for DynamoDB which is responsible for results reporting, although providing some naive reporters, to be used on local machine is out of scope for this PR.