### PR TITLE
Initial metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,8 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",
   "com.geteventstore" %% "eventstore-client" % "3.0.4",
   "org.apache.activemq" % "activemq-client" % "5.14.2",
-  "com.typesafe" % "config" % "1.3.1"
+  "com.typesafe" % "config" % "1.3.1",
+  "io.dropwizard.metrics" % "metrics-core" % "3.1.0"
 )
 
 assemblyOption in assembly ~= {

--- a/src/main/scala/com/softwaremill/mqperf/DynamoResultsTable.scala
+++ b/src/main/scala/com/softwaremill/mqperf/DynamoResultsTable.scala
@@ -18,16 +18,27 @@ trait DynamoResultsTable {
     }
 
   protected val tableName = "mqperf-results"
-
   protected val resultNameColumn = "test_result_name"
+  protected val histogramMinColumn = "histogram_min"
+  protected val histogramMaxColumn = "histogram_max"
+  protected val histogramMeanColumn = "histogram_mean"
+  protected val histogramMedianColumn = "histogram_median"
+  protected val histogramStdDevColumn = "histogram_std_dev"
+  protected val histogram75thPercentileColumn = "histogram_75th_perc"
+  protected val histogram95thPercentileColumn = "histogram_95th_perc"
+  protected val histogram98thPercentileColumn = "histogram_98th_perc"
+  protected val histogram99thPercentileColumn = "histogram_99th_perc"
+  protected val timerMinColumn = "timer_min"
+  protected val timerMaxColumn = "timer_max"
+  protected val timerMeanColumn = "timer_mean"
+  protected val timerMedianColumn = "timer_median"
+  protected val timerStdDevColumn = "timer_st_dev"
+  protected val timer75thPercentileColumn = "timer_75th_perc"
+  protected val timer95thPercentileColumn = "timer_95th_perc"
+  protected val timer98thPercentileColumn = "timer_98th_perc"
+  protected val timer99thPercentileColumn = "timer_99th_perc"
   protected val msgsCountColumn = "msgs_count"
-  protected val tookColumn = "took"
-  protected val startColumn = "start"
-  protected val endColumn = "end"
   protected val typeColumn = "type"
-
-  protected val typeSend = "s"
-  protected val typeReceive = "r"
 }
 
 object ClearDynamoResultsTable extends App with DynamoResultsTable {

--- a/src/main/scala/com/softwaremill/mqperf/Receiver.scala
+++ b/src/main/scala/com/softwaremill/mqperf/Receiver.scala
@@ -39,7 +39,7 @@ class ReceiverRunnable(
     receiveMsgBatchSize: Int
 ) extends Runnable with StrictLogging {
 
-  val timeout = 16.seconds
+  val timeout = 60.seconds
   val timeoutNanos = timeout.toNanos
 
   val metricRegistry = new MetricRegistry()

--- a/src/main/scala/com/softwaremill/mqperf/Receiver.scala
+++ b/src/main/scala/com/softwaremill/mqperf/Receiver.scala
@@ -1,7 +1,12 @@
 package com.softwaremill.mqperf
 
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration._
+import com.codahale.metrics.MetricRegistry
 import com.softwaremill.mqperf.config.TestConfigOnS3
 import com.softwaremill.mqperf.mq.Mq
+import com.typesafe.scalalogging.{LazyLogging, StrictLogging}
 
 object Receiver extends App {
   println("Starting receiver...")
@@ -10,6 +15,7 @@ object Receiver extends App {
 
     val mq = Mq.instantiate(testConfig)
     val report = new ReportResults(testConfig.name)
+
     val rr = new ReceiverRunnable(
       mq, report,
       testConfig.receiveMsgBatchSize
@@ -31,36 +37,49 @@ class ReceiverRunnable(
     mq: Mq,
     reportResults: ReportResults,
     receiveMsgBatchSize: Int
-) extends Runnable {
+) extends Runnable with StrictLogging {
+
+  val timeout = 16.seconds
+  val timeoutNanos = timeout.toNanos
+
+  val metricRegistry = new MetricRegistry()
+  val msgTimer = metricRegistry.timer("kafka-receiver-messages-timer")
+  val histogram = metricRegistry.histogram("kafka-receiver-messages-histogram")
 
   override def run(): Unit = {
     val mqReceiver = mq.createReceiver()
+    try {
+      val start = System.nanoTime()
+      var lastReceivedNano = start
 
-    val start = System.currentTimeMillis()
-    var lastReceived = System.currentTimeMillis()
-    var totalReceived = 0
-
-    while ((System.currentTimeMillis() - lastReceived) < 60 * 1000L) {
-      val received = doReceive(mqReceiver)
-
-      if (received > 0) {
-        lastReceived = System.currentTimeMillis()
+      while (System.nanoTime() - lastReceivedNano < timeoutNanos) {
+        val received = doReceive(mqReceiver)
+        if (received > 0) {
+          val nowNano = System.nanoTime()
+          val nowSeconds = nowNano / 1000000000L
+          lastReceivedNano = nowNano
+          (0 to received).foreach(_ => histogram.update(nowSeconds))
+        }
       }
-
-      totalReceived += received
+      logger.info(s"Test finished, last message read $timeout ago")
+      TestMetrics.receive(metricRegistry).foreach(reportResults.report)
     }
-
-    reportResults.reportReceivingComplete(start, lastReceived, totalReceived)
-    mqReceiver.close()
+    finally {
+      mqReceiver.close()
+    }
   }
 
   private def doReceive(mqReceiver: mq.MqReceiver) = {
+    val before = System.nanoTime()
     val msgs = mqReceiver.receive(receiveMsgBatchSize)
+    if (msgs.nonEmpty) {
+      val after = System.nanoTime()
+      msgTimer.update(after - before, TimeUnit.NANOSECONDS)
+    }
     val ids = msgs.map(_._1)
     if (ids.nonEmpty) {
       mqReceiver.ack(ids)
     }
-
     ids.size
   }
 }

--- a/src/main/scala/com/softwaremill/mqperf/ReportResults.scala
+++ b/src/main/scala/com/softwaremill/mqperf/ReportResults.scala
@@ -28,6 +28,7 @@ class ReportResults(testConfigName: String) extends DynamoResultsTable with Stri
     dynamoClient.putItem(new PutItemRequest()
       .withTableName(tableName)
       .addItemEntry(resultNameColumn, new AttributeValue(testResultName))
+      .addItemEntry(typeColumn, new AttributeValue(metrics.name))
       .addItemEntry(histogramMinColumn, histogram.getMin)
       .addItemEntry(histogramMaxColumn, histogram.getMax)
       .addItemEntry(histogramMeanColumn, histogram.getMean)

--- a/src/main/scala/com/softwaremill/mqperf/Sender.scala
+++ b/src/main/scala/com/softwaremill/mqperf/Sender.scala
@@ -1,6 +1,10 @@
 package com.softwaremill.mqperf
 
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics.MetricRegistry
 import com.softwaremill.mqperf.mq.Mq
+
 import scala.util.Random
 import com.softwaremill.mqperf.config.TestConfigOnS3
 
@@ -32,20 +36,32 @@ object Sender extends App {
 class SenderRunnable(mq: Mq, reportResults: ReportResults,
     msg: String, msgCount: Int, maxSendMsgBatchSize: Int) extends Runnable {
 
+  val metricRegistry = new MetricRegistry()
+  val msgTimer = metricRegistry.timer("kafka-sender-messages-timer")
+  val histogram = metricRegistry.histogram("kafka-sender-messages-histogram")
+
   override def run() = {
     val mqSender = mq.createSender()
-    val start = System.currentTimeMillis()
-    doSend(mqSender)
-    val end = System.currentTimeMillis()
-    reportResults.reportSendingComplete(start, end, msgCount)
-    mqSender.close()
+    try {
+      doSend(mqSender)
+      TestMetrics.send(metricRegistry).foreach(reportResults.report)
+    }
+    finally {
+      mqSender.close()
+    }
   }
 
   private def doSend(mqSender: mq.MqSender) {
     var leftToSend = msgCount
     while (leftToSend > 0) {
       val batchSize = math.min(leftToSend, Random.nextInt(maxSendMsgBatchSize) + 1)
-      mqSender.send(List.fill(batchSize)(msg))
+      val batch = List.fill(batchSize)(msg)
+      val before = System.nanoTime()
+      mqSender.send(batch)
+      val after = System.nanoTime()
+      val nowSeconds = after / 1000000000L
+      batch.foreach(_ => histogram.update(nowSeconds))
+      msgTimer.update(after - before, TimeUnit.NANOSECONDS)
       leftToSend -= batchSize
     }
   }

--- a/src/main/scala/com/softwaremill/mqperf/config/TestConfigOnS3.scala
+++ b/src/main/scala/com/softwaremill/mqperf/config/TestConfigOnS3.scala
@@ -12,7 +12,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 class TestConfigOnS3(private val objectName: String) {
 
   private val s3ClientOpt: Option[AmazonS3Client] = AWSCredentialsFromEnv(TestConfigOnS3.LocalConfig).map(new AmazonS3Client(_))
-  private val bucketName = "mqperf"
+  private val bucketName = "mqperf-2"
   private val whenChangedPollEveryMs = 1000L
 
   def this() = this("test_config.json")

--- a/src/main/scala/com/softwaremill/mqperf/stats/ShowStats.scala
+++ b/src/main/scala/com/softwaremill/mqperf/stats/ShowStats.scala
@@ -82,9 +82,9 @@ object ShowStats extends App with DynamoResultsTable {
       .toList
   }
 
-  val prefix = if (args.nonEmpty) args(0) else "sqs1-1401970126140"
+  val prefix = if (args.nonEmpty) args(0) else "kafka"
 
-  val allResults = fetchResultsWithPrefix(prefix) //.sortBy(-_.msgsPerSecond)
+  val allResults = fetchResultsWithPrefix(prefix)
   val (sendResults, receiveResults) = allResults.partition(_._type == TestMetrics.typeSend)
 
   def printResults(results: List[Result], _type: String) {


### PR DESCRIPTION
This PR introduces dropwizard metrics library for collecting test stats.
1. Histogram is used to observe throughput. We increase histogram "bars" for each message in a particular second.
2. Timer is used to observe latency. We calculate time spent on single "request".
3. Data is stored in DynamoDB.
4. One missing part is formatting in `ShowStats`. Once we agree that we have the correct data stored, we can polish this in a separate PR.