### PR TITLE
Run block in whenChanged() on first call

### DIFF
--- a/src/main/scala/com/softwaremill/mqperf/config/TestConfigOnS3.scala
+++ b/src/main/scala/com/softwaremill/mqperf/config/TestConfigOnS3.scala
@@ -60,6 +60,7 @@ class TestConfigOnS3(private val objectName: String) {
   def whenChanged(block: TestConfig => Unit) {
     lastModified() match {
       case Some(lm) =>
+        block(read())
         var lastMod = lastModified()
         while (true) {
           Thread.sleep(whenChangedPollEveryMs)


### PR DESCRIPTION
Running `Sender` or `Receiver` with configured AWS access will do nothing until config found in S3 changes. 
This update changes the behavior: tests run always once and then we wait for updates in s3 configuration.