### PR TITLE
Refine metrics

### DIFF
--- a/src/main/scala/com/softwaremill/mqperf/DynamoResultsTable.scala
+++ b/src/main/scala/com/softwaremill/mqperf/DynamoResultsTable.scala
@@ -31,8 +31,16 @@ trait DynamoResultsTable {
   protected val timer95thPercentileColumn = "timer_95th_perc"
   protected val timer98thPercentileColumn = "timer_98th_perc"
   protected val timer99thPercentileColumn = "timer_99th_perc"
+  protected val clusterTimerMinColumn = "clusterTimer_min"
+  protected val clusterTimerMaxColumn = "clusterTimer_max"
+  protected val clusterTimerMeanColumn = "clusterTimer_mean"
+  protected val clusterTimerMedianColumn = "clusterTimer_median"
+  protected val clusterTimerStdDevColumn = "clusterTimer_st_dev"
+  protected val clusterTimer75thPercentileColumn = "clusterTimer_75th_perc"
+  protected val clusterTimer95thPercentileColumn = "clusterTimer_95th_perc"
+  protected val clusterTimer98thPercentileColumn = "clusterTimer_98th_perc"
+  protected val clusterTimer99thPercentileColumn = "clusterTimer_99th_perc"
   protected val msgsCountColumn = "msgs_count"
-  protected val typeColumn = "type"
 }
 
 object ClearDynamoResultsTable extends App with DynamoResultsTable {

--- a/src/main/scala/com/softwaremill/mqperf/ReportResults.scala
+++ b/src/main/scala/com/softwaremill/mqperf/ReportResults.scala
@@ -5,13 +5,13 @@ import com.amazonaws.services.dynamodbv2.model.{AttributeValue, PutItemRequest}
 import com.codahale.metrics._
 import com.typesafe.scalalogging.StrictLogging
 import org.joda.time.DateTime
-
 import scala.collection.JavaConverters._
+import scala.language.implicitConversions
 import scala.util.Random
 
 class ReportResults(testConfigName: String) extends DynamoResultsTable with StrictLogging {
 
-  def report(metrics: TestMetrics): Unit = {
+  def report(metrics: ReceiverMetrics): Unit = {
     Slf4jReporter.forRegistry(metrics.raw).build().report()
     if (dynamoClientOpt.isEmpty) {
       logger.warn("Report requested but Dynamo client not defined.")
@@ -20,10 +20,11 @@ class ReportResults(testConfigName: String) extends DynamoResultsTable with Stri
       dynamoClientOpt.foreach(exportStats(metrics))
   }
 
-  private def exportStats(metrics: TestMetrics)(dynamoClient: AmazonDynamoDBClient): Unit = {
+  private def exportStats(metrics: ReceiverMetrics)(dynamoClient: AmazonDynamoDBClient): Unit = {
 
-    val testResultName = s"$testConfigName-${metrics.name}-${Random.nextInt(100000)}"
+    val testResultName = s"$testConfigName-${Random.nextInt(100000)}"
     val meter = metrics.meter
+    val clusterTimer = metrics.clusterTimer.getSnapshot
     val timer = metrics.timer.getSnapshot
     logger.info(s"Storing results in DynamoDB: $testResultName")
 
@@ -31,7 +32,6 @@ class ReportResults(testConfigName: String) extends DynamoResultsTable with Stri
       .withTableName(tableName)
       .addItemEntry(resultNameColumn, new AttributeValue(testResultName))
       .addItemEntry(resultTimestampColumn, metrics.timestamp.getMillis)
-      .addItemEntry(typeColumn, new AttributeValue(metrics.name))
       .addItemEntry(meterMean, meter.getMeanRate)
       .addItemEntry(meter1MinuteEwma, meter.getOneMinuteRate)
       .addItemEntry(timerMinColumn, timer.getMin)
@@ -43,6 +43,15 @@ class ReportResults(testConfigName: String) extends DynamoResultsTable with Stri
       .addItemEntry(timer95thPercentileColumn, timer.get95thPercentile)
       .addItemEntry(timer98thPercentileColumn, timer.get98thPercentile)
       .addItemEntry(timer99thPercentileColumn, timer.get99thPercentile)
+      .addItemEntry(clusterTimerMinColumn, clusterTimer.getMin)
+      .addItemEntry(clusterTimerMaxColumn, clusterTimer.getMax)
+      .addItemEntry(clusterTimerMeanColumn, clusterTimer.getMean)
+      .addItemEntry(clusterTimerMedianColumn, clusterTimer.getMedian)
+      .addItemEntry(clusterTimerStdDevColumn, clusterTimer.getStdDev)
+      .addItemEntry(clusterTimer75thPercentileColumn, clusterTimer.get75thPercentile)
+      .addItemEntry(clusterTimer95thPercentileColumn, clusterTimer.get95thPercentile)
+      .addItemEntry(clusterTimer98thPercentileColumn, clusterTimer.get98thPercentile)
+      .addItemEntry(clusterTimer99thPercentileColumn, clusterTimer.get99thPercentile)
       .addItemEntry(msgsCountColumn, new AttributeValue().withN(meter.getCount.toString)))
     logger.info(s"Test results stored: $testResultName")
   }
@@ -52,23 +61,25 @@ class ReportResults(testConfigName: String) extends DynamoResultsTable with Stri
   implicit def doubleToDynamoAttr(d: Double): AttributeValue = new AttributeValue().withN(d.toString)
 }
 
-case class TestMetrics(name: String, timestamp: DateTime, timer: Timer, meter: Meter, raw: MetricRegistry)
+case class ReceiverMetrics(timestamp: DateTime, timer: Timer, meter: Meter, clusterTimer: Timer, raw: MetricRegistry)
 
-object TestMetrics extends StrictLogging {
+object ReceiverMetrics extends StrictLogging {
 
-  val typeSend = "s"
-  val typeReceive = "r"
+  val batchThroughputMeter = "receiver-meter"
+  val batchLatencyTimerPrefix = "batch-latency-timer"
+  val clusterLatencyTimerPrefix = "cluster-latency-timer"
 
-  def receive(metrics: MetricRegistry): Option[TestMetrics] = apply(typeReceive, metrics)
-
-  def send(metrics: MetricRegistry): Option[TestMetrics] = apply(typeSend, metrics)
-
-  def apply(name: String, metrics: MetricRegistry): Option[TestMetrics] = {
+  def apply(metrics: MetricRegistry): Option[ReceiverMetrics] = {
     val resultOpt = for {
       (_, timer) <- metrics.getTimers.asScala.headOption
-      (_, meter) <- metrics.getMeters.asScala.headOption
+      (_, meter) <- metrics.getMeters.asScala.find {
+        case (name, _) => name.startsWith(batchLatencyTimerPrefix)
+      }
+      (_, clusterTimer) <- metrics.getTimers.asScala.find {
+        case (name, _) => name.startsWith(clusterLatencyTimerPrefix)
+      }
     } yield {
-      new TestMetrics(name, DateTime.now(), timer, meter, metrics)
+      new ReceiverMetrics(DateTime.now(), timer, meter, clusterTimer, metrics)
     }
     if (resultOpt.isEmpty)
       logger.error("Cannot create result object with metrics.")

--- a/src/main/scala/com/softwaremill/mqperf/Sender.scala
+++ b/src/main/scala/com/softwaremill/mqperf/Sender.scala
@@ -61,9 +61,10 @@ class SenderRunnable(mq: Mq, reportResults: ReportResults, mqType: String,
     logger.info(s"Sending $leftToSend messages")
     while (leftToSend > 0) {
       val batchSize = math.min(leftToSend, Random.nextInt(maxSendMsgBatchSize) + 1)
-      val batch = List.fill(batchSize)(msg)
-      val before = System.nanoTime()
+      val fullMsg = msg + "_" + System.currentTimeMillis().toString
+      val batch = List.fill(batchSize)(fullMsg)
       logger.debug("Sending batch")
+      val before = System.nanoTime()
       mqSender.send(batch)
       val after = System.nanoTime()
       meter.mark(batch.length)

--- a/src/main/scala/com/softwaremill/mqperf/Sender.scala
+++ b/src/main/scala/com/softwaremill/mqperf/Sender.scala
@@ -1,12 +1,10 @@
 package com.softwaremill.mqperf
 
 import java.util.concurrent.TimeUnit
-
 import com.codahale.metrics.{Meter, MetricRegistry, Timer}
 import com.softwaremill.mqperf.config.TestConfigOnS3
 import com.softwaremill.mqperf.mq.Mq
 import com.typesafe.scalalogging.StrictLogging
-
 import scala.util.Random
 
 object Sender extends App {
@@ -36,9 +34,6 @@ object Sender extends App {
 
 class SenderRunnable(mq: Mq, reportResults: ReportResults, mqType: String,
     msg: String, msgCount: Int, maxSendMsgBatchSize: Int) extends Runnable with StrictLogging {
-
-  val metricRegistry = new MetricRegistry()
-  val msgTimer = metricRegistry.timer(s"$mqType-sender-timer")
 
   override def run() = {
     val metricRegistry = new MetricRegistry()

--- a/src/main/scala/com/softwaremill/mqperf/Sender.scala
+++ b/src/main/scala/com/softwaremill/mqperf/Sender.scala
@@ -1,10 +1,10 @@
 package com.softwaremill.mqperf
 
-import java.util.concurrent.TimeUnit
-import com.codahale.metrics.{Meter, MetricRegistry, Timer}
+import com.codahale.metrics.{Meter, Timer}
 import com.softwaremill.mqperf.config.TestConfigOnS3
 import com.softwaremill.mqperf.mq.Mq
 import com.typesafe.scalalogging.StrictLogging
+
 import scala.util.Random
 
 object Sender extends App {
@@ -36,15 +36,18 @@ class SenderRunnable(mq: Mq, reportResults: ReportResults, mqType: String,
     msg: String, msgCount: Int, maxSendMsgBatchSize: Int) extends Runnable with StrictLogging {
 
   override def run() = {
-    val metricRegistry = new MetricRegistry()
-    val threadId = Thread.currentThread().getId
-    val msgTimer = metricRegistry.timer(s"sender-timer-$threadId")
-    val meter = metricRegistry.meter(s"sender-meter-$threadId")
     val mqSender = mq.createSender()
-    val start = System.nanoTime()
     try {
-      doSend(mqSender, msgTimer, meter, start)
-      TestMetrics.send(metricRegistry).foreach(reportResults.report)
+      var leftToSend = msgCount
+      logger.info(s"Sending $leftToSend messages")
+      while (leftToSend > 0) {
+        val batchSize = math.min(leftToSend, Random.nextInt(maxSendMsgBatchSize) + 1)
+        val fullMsg = msg + "_" + System.currentTimeMillis().toString
+        val batch = List.fill(batchSize)(fullMsg)
+        logger.debug("Sending batch")
+        mqSender.send(batch)
+        leftToSend -= batchSize
+      }
     }
     finally {
       mqSender.close()
@@ -52,19 +55,5 @@ class SenderRunnable(mq: Mq, reportResults: ReportResults, mqType: String,
   }
 
   private def doSend(mqSender: mq.MqSender, msgTimer: Timer, meter: Meter, start: Long) {
-    var leftToSend = msgCount
-    logger.info(s"Sending $leftToSend messages")
-    while (leftToSend > 0) {
-      val batchSize = math.min(leftToSend, Random.nextInt(maxSendMsgBatchSize) + 1)
-      val fullMsg = msg + "_" + System.currentTimeMillis().toString
-      val batch = List.fill(batchSize)(fullMsg)
-      logger.debug("Sending batch")
-      val before = System.nanoTime()
-      mqSender.send(batch)
-      val after = System.nanoTime()
-      meter.mark(batch.length)
-      msgTimer.update(after - before, TimeUnit.NANOSECONDS)
-      leftToSend -= batchSize
-    }
   }
 }

--- a/src/main/scala/com/softwaremill/mqperf/mq/KafkaMq.scala
+++ b/src/main/scala/com/softwaremill/mqperf/mq/KafkaMq.scala
@@ -41,7 +41,7 @@ class KafkaMq(configMap: Map[String, String]) extends Mq with StrictLogging {
         send(msgs)
       else if (msgs.nonEmpty) {
         sendingMsg = true
-        producer.send(new ProducerRecord[String, String](Topic, r.nextString(5), msgs.head), new Callback {
+        producer.send(new ProducerRecord[String, String](Topic, r.nextString(5), withTimestamp(msgs.head)), new Callback {
           override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit = {
             // This callback is executed on the same thread, so we can safely access mutable state
             sendingMsg = false

--- a/src/main/scala/com/softwaremill/mqperf/mq/Mq.scala
+++ b/src/main/scala/com/softwaremill/mqperf/mq/Mq.scala
@@ -12,6 +12,10 @@ trait Mq {
     def send(msgs: List[String])
 
     def close() {}
+
+    def withTimestamp(msg: String): String = msg + "_" + System.currentTimeMillis().toString
+
+    def extractTimestamp(msg: String): Long = msg.substring(msg.indexOf('_') + 1).toLong
   }
 
   trait MqReceiver {

--- a/src/main/scala/com/softwaremill/mqperf/stats/Result.scala
+++ b/src/main/scala/com/softwaremill/mqperf/stats/Result.scala
@@ -5,21 +5,38 @@ import java.util.Locale
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
 
+case class TimerResult(
+    name: String,
+    min: Long,
+    max: Long,
+    mean: Double,
+    median: Double,
+    stdDev: Double,
+    p75th: Double,
+    p95th: Double,
+    p98th: Double,
+    p99th: Double
+) {
+  override def toString: String = {
+    f"""Timer ($name)
+  |${min / 1000000L}%12d min ms
+  |${max / 1000000L}%12d max ms
+  |${mean / 1000000L}%12.2f mean ms
+  |${median / 1000000L}%12.2f median ms
+  |${stdDev / 1000000L}%12.2f std dev ms
+  |${p75th / 1000000L}%12.2f ms (75th percentile)
+  |${p95th / 1000000L}%12.2f ms (95th percentile)
+  |${p98th / 1000000L}%12.2f ms (98th percentile)
+  |${p99th / 1000000L}%12.2f ms (99th percentile)""".stripMargin
+  }
+}
 case class Result(
     timestamp: DateTime,
     msgCount: Long,
-    _type: String,
     meterMean: Double,
     meter1MinEwma: Double,
-    timerMin: Long,
-    timerMax: Long,
-    timerMean: Double,
-    timerMedian: Double,
-    timerStdDev: Double,
-    timer75thPercentile: Double,
-    timer95thPercentile: Double,
-    timer98thPercentile: Double,
-    timer99thPercentile: Double
+    timer: TimerResult,
+    clusterTimer: TimerResult
 ) {
   override def toString: String = {
     val dt = Result.dtFormatter.print(timestamp)
@@ -27,15 +44,8 @@ case class Result(
        |$msgCount%12d total messages
        |$meterMean%12.0f mean msgs/s
        |$meter1MinEwma%12.0f 1 min EWMA msgs/s
-       |${timerMin / 1000000L}%12d min latency ms
-       |${timerMax / 1000000L}%12d max latency ms
-       |${timerMean / 1000000L}%12.2f mean latency ms
-       |${timerMedian / 1000000L}%12.2f median latency ms
-       |${timerStdDev / 1000000L}%12.2f std dev latency ms
-       |${timer75thPercentile / 1000000L}%12.2f latency ms (75th percentile)
-       |${timer95thPercentile / 1000000L}%12.2f latency ms (95th percentile)
-       |${timer98thPercentile / 1000000L}%12.2f latency ms (98th percentile)
-       |${timer99thPercentile / 1000000L}%12.2f latency ms (99th percentile)""".stripMargin
+       |$timer
+       |$clusterTimer""".stripMargin
   }
 }
 

--- a/src/main/scala/com/softwaremill/mqperf/stats/ShowStats.scala
+++ b/src/main/scala/com/softwaremill/mqperf/stats/ShowStats.scala
@@ -1,9 +1,8 @@
 package com.softwaremill.mqperf.stats
 
-import com.softwaremill.mqperf.{DynamoResultsTable, TestMetrics}
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, ComparisonOperator, Condition, ScanRequest}
+import com.softwaremill.mqperf.{DynamoResultsTable, ReceiverMetrics}
 import org.joda.time.{DateTime, DateTimeZone}
-
 import scala.collection.JavaConverters._
 
 object ShowStats extends App with DynamoResultsTable {
@@ -39,18 +38,32 @@ object ShowStats extends App with DynamoResultsTable {
         Result(
           new DateTime(i.get(resultTimestampColumn).getN.toLong).withZone(DateTimeZone.UTC),
           i.get(msgsCountColumn).getN.toLong,
-          i.get(typeColumn).getS,
           i.get(meterMean).getN.toDouble,
           i.get(meter1MinuteEwma).getN.toDouble,
-          i.get(timerMinColumn).getN.toLong,
-          i.get(timerMaxColumn).getN.toLong,
-          i.get(timerMeanColumn).getN.toDouble,
-          i.get(timerMedianColumn).getN.toDouble,
-          i.get(timerStdDevColumn).getN.toDouble,
-          i.get(timer75thPercentileColumn).getN.toDouble,
-          i.get(timer95thPercentileColumn).getN.toDouble,
-          i.get(timer98thPercentileColumn).getN.toDouble,
-          i.get(timer99thPercentileColumn).getN.toDouble
+          TimerResult(
+            ReceiverMetrics.batchLatencyTimerPrefix,
+            i.get(timerMinColumn).getN.toLong,
+            i.get(timerMaxColumn).getN.toLong,
+            i.get(timerMeanColumn).getN.toDouble,
+            i.get(timerMedianColumn).getN.toDouble,
+            i.get(timerStdDevColumn).getN.toDouble,
+            i.get(timer75thPercentileColumn).getN.toDouble,
+            i.get(timer95thPercentileColumn).getN.toDouble,
+            i.get(timer98thPercentileColumn).getN.toDouble,
+            i.get(timer99thPercentileColumn).getN.toDouble
+          ),
+          TimerResult(
+            ReceiverMetrics.clusterLatencyTimerPrefix,
+            i.get(clusterTimerMinColumn).getN.toLong,
+            i.get(clusterTimerMaxColumn).getN.toLong,
+            i.get(clusterTimerMeanColumn).getN.toDouble,
+            i.get(clusterTimerMedianColumn).getN.toDouble,
+            i.get(clusterTimerStdDevColumn).getN.toDouble,
+            i.get(clusterTimer75thPercentileColumn).getN.toDouble,
+            i.get(clusterTimer95thPercentileColumn).getN.toDouble,
+            i.get(clusterTimer98thPercentileColumn).getN.toDouble,
+            i.get(clusterTimer99thPercentileColumn).getN.toDouble
+          )
         )
       })
       .toList
@@ -59,13 +72,11 @@ object ShowStats extends App with DynamoResultsTable {
   val prefix = if (args.nonEmpty) args(0) else "kafka"
 
   val allResults = fetchResultsWithPrefix(prefix)
-  val (sendResults, receiveResults) = allResults.partition(_._type == TestMetrics.typeSend)
 
   def printResults(results: List[Result], _type: String) {
     println(s"Results for $prefix, ${_type}")
     results.foreach(println)
     println("---\n")
   }
-  printResults(sendResults, "send")
-  printResults(receiveResults, "receive")
+  printResults(allResults, "send")
 }

--- a/src/test/scala/com/softwaremill/mqperf/stats/ResultTest.scala
+++ b/src/test/scala/com/softwaremill/mqperf/stats/ResultTest.scala
@@ -14,8 +14,14 @@ class ResultTest extends FlatSpec with Matchers {
     Locale.setDefault(Locale.US)
     val resultAsPrettyString = Result(
       new DateTime(1483019133000L),
-      3250346112L, "r", 21217.55, 21223.32, 7211L, 23301401L, 10627650.458852611, 9463284, 8410536.830270134, 23301401,
-      23301301, 23201401, 23101401
+      3250346112L, 21217.55, 20217.55, TimerResult(
+        "latency", 7211L, 23301401L, 10627650.458852611, 9463284, 8410536.830270134, 23301401,
+        23301301, 23201401, 23101401
+      ),
+      TimerResult(
+        "cluster latency", 6211L, 13301401L, 5627650.458852611, 8463284, 7410536.830270134, 13301401,
+        13301301, 13201401, 13101401
+      )
     ).toString
 
     Locale.setDefault(defaultLocale)
@@ -24,16 +30,27 @@ class ResultTest extends FlatSpec with Matchers {
       """Test time: 29/12/16 13:45 UTC
         |  3250346112 total messages
         |       21218 mean msgs/s
-        |       21223 1 min EWMA msgs/s
-        |           0 min latency ms
-        |          23 max latency ms
-        |       10.63 mean latency ms
-        |        9.46 median latency ms
-        |        8.41 std dev latency ms
-        |       23.30 latency ms (75th percentile)
-        |       23.30 latency ms (95th percentile)
-        |       23.20 latency ms (98th percentile)
-        |       23.10 latency ms (99th percentile)""".stripMargin
+        |       20218 1 min EWMA msgs/s
+        |Timer (latency)
+        |           0 min ms
+        |          23 max ms
+        |       10.63 mean ms
+        |        9.46 median ms
+        |        8.41 std dev ms
+        |       23.30 ms (75th percentile)
+        |       23.30 ms (95th percentile)
+        |       23.20 ms (98th percentile)
+        |       23.10 ms (99th percentile)
+        |Timer (cluster latency)
+        |           0 min ms
+        |          13 max ms
+        |        5.63 mean ms
+        |        8.46 median ms
+        |        7.41 std dev ms
+        |       13.30 ms (75th percentile)
+        |       13.30 ms (95th percentile)
+        |       13.20 ms (98th percentile)
+        |       13.10 ms (99th percentile)""".stripMargin
     )
   }
 }


### PR DESCRIPTION
Metrics after this update:
1. ~sender throughput~ removed
2. ~sender latency~ removed
3. receiver throughput 
4. receiver latency (time to read a single batch)
5. cluster latency (based on timestamp in message)