### PR TITLE
PostgresMq

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,16 +360,18 @@ curl -XPOST -d'{"testId":"test","testLengthSeconds":10,"msgsPerSecond":10,"msgSi
 To test the senders/receivers using PostgresMQ, you might build the docker image locally using:
 
 ```
-sbt postgresmq/docker:publishLocal
+sbt postgres/docker:publishLocal
 ```
 
-Then, go to `docker/postgresmq` and run `docker-compose up`. This will start the PostgreSQL server.
+Then, go to `docker/postgres` and run `docker-compose up`. This will start the PostgreSQL server.
 
 To init, then start the sender/receiver, use the following commands, using appropriate endpoints:
 
 ```bash
-curl -XPOST -d'{"testId":"test","testLengthSeconds":20,"msgsPerSecond":40,"msgSizeBytes":100,"batchSizeSend":10,"batchSizeReceive":1,"maxSendInFlight":40,"mqConfig":{"hosts":"rabbitmq","username":"guest","password":"guest","queueName":"mqperf-test","maxPollAttempts":"10","qos":"100","multipleAck":"true","maxChannelsNr":"10"}}' http://localhost:8080/init
+curl -XPOST -d'{"testId":"test","testLengthSeconds":20,"msgsPerSecond":40,"msgSizeBytes":100,"batchSizeSend":10,"batchSizeReceive":1,"maxSendInFlight":40,"mqConfig":{"host": "postgres", "port": "5432", "table": "jobs"}}' http://localhost:8080/init
 ```
+
+You can also check sample requests in `postgresMq.http` file.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -363,7 +363,11 @@ To test the senders/receivers using PostgresMQ, you might build the docker image
 sbt postgres/docker:publishLocal
 ```
 
-Then, go to `docker/postgres` and run `docker-compose up`. This will start the PostgreSQL server.
+Then, go to `docker/postgres` and run:
+```
+docker-compose -f ../metrics/docker-compose.metrics.yml -f docker-compose.yml -p postgres up
+```
+This will start the PostgreSQL server and the mqperf server.
 
 To init, then start the sender/receiver, use the following commands, using appropriate endpoints:
 

--- a/README.md
+++ b/README.md
@@ -355,6 +355,22 @@ To init, then start the sender/receiver, use the following commands, using appro
 curl -XPOST -d'{"testId":"test","testLengthSeconds":10,"msgsPerSecond":10,"msgSizeBytes":100,"batchSizeSend":1,"batchSizeReceive":1,"maxSendInFlight":1,"mqConfig":{"hosts":"broker:29092","topic":"mqperf-test","acks":"-1","groupId":"mqperf","commitMs":"1000","partitions":"10","replicationFactor":"1"}}' http://localhost:8080/init
 ```
 
+### PostgresMQ
+
+To test the senders/receivers using PostgresMQ, you might build the docker image locally using:
+
+```
+sbt postgresmq/docker:publishLocal
+```
+
+Then, go to `docker/postgresmq` and run `docker-compose up`. This will start the PostgreSQL server.
+
+To init, then start the sender/receiver, use the following commands, using appropriate endpoints:
+
+```bash
+curl -XPOST -d'{"testId":"test","testLengthSeconds":20,"msgsPerSecond":40,"msgSizeBytes":100,"batchSizeSend":10,"batchSizeReceive":1,"maxSendInFlight":40,"mqConfig":{"hosts":"rabbitmq","username":"guest","password":"guest","queueName":"mqperf-test","maxPollAttempts":"10","qos":"100","multipleAck":"true","maxChannelsNr":"10"}}' http://localhost:8080/init
+```
+
 ## Copyright
 
 Copyright (C) 2013-2022 SoftwareMill [https://softwaremill.com](https://softwaremill.com).

--- a/build.sbt
+++ b/build.sbt
@@ -62,8 +62,9 @@ lazy val postgres: Project = (project in file("clients/postgres"))
   .settings(
     name := "postgres",
     libraryDependencies ++= Seq(
-      "org.postgresql" % "r2dbc-postgresql" % "1.0.0.RELEASE",
-      "io.r2dbc" % "r2dbc-pool" % "1.0.0.RELEASE",
+      "org.postgresql" % "r2dbc-postgresql" % "0.9.2.RELEASE",
+      "io.r2dbc" % "r2dbc-pool" % "0.9.2.RELEASE",
+      "org.springframework.data" % "spring-data-r2dbc" % "1.5.6",
       scalaTest
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,8 @@ lazy val postgres: Project = (project in file("clients/postgres"))
   .settings(
     name := "postgres",
     libraryDependencies ++= Seq(
+      "org.postgresql" % "r2dbc-postgresql" % "1.0.0.RELEASE",
+      "io.r2dbc" % "r2dbc-pool" % "1.0.0.RELEASE",
       scalaTest
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val dockerSettings = Seq(
 lazy val rootProject = (project in file("."))
   .settings(commonSettings: _*)
   .settings(publishArtifact := false, name := "root")
-  .aggregate(core, kafka)
+  .aggregate(core, kafka, postgres)
 
 lazy val core: Project = (project in file("clients/core"))
   .settings(commonSettings: _*)
@@ -48,6 +48,20 @@ lazy val kafka: Project = (project in file("clients/kafka"))
     name := "kafka",
     libraryDependencies ++= Seq(
       "org.apache.kafka" % "kafka-clients" % "3.2.3",
+      scalaTest
+    )
+  )
+  .dependsOn(core)
+  .enablePlugins(JavaServerAppPackaging)
+  .enablePlugins(DockerPlugin)
+
+lazy val postgres: Project = (project in file("clients/postgres"))
+  .settings(commonSettings: _*)
+  .settings(dockerSettings)
+  .settings(Docker / packageName := "mqperf-postgres")
+  .settings(
+    name := "postgres",
+    libraryDependencies ++= Seq(
       scalaTest
     )
   )

--- a/clients/postgres/src/main/scala/mqperf/postgres/PostgresMain.scala
+++ b/clients/postgres/src/main/scala/mqperf/postgres/PostgresMain.scala
@@ -1,0 +1,9 @@
+package mqperf.postgres
+
+import mqperf.Server
+
+import java.time.Clock
+
+object PostgresMain extends App {
+  Server.start(new PostgresMq(Clock.systemUTC()))
+}

--- a/clients/postgres/src/main/scala/mqperf/postgres/PostgresMq.scala
+++ b/clients/postgres/src/main/scala/mqperf/postgres/PostgresMq.scala
@@ -1,0 +1,22 @@
+package mqperf.postgres
+
+import mqperf.{Config, Mq, MqReceiver, MqSender}
+
+import scala.concurrent.Future
+
+class PostgresMq(clock: java.time.Clock) extends Mq {
+  override def init(config: Config): Unit = ???
+
+  override def cleanUp(config: Config): Unit = ???
+
+  override def createSender(config: Config): MqSender = new MqSender {
+    override def send(msgs: Seq[String]): Future[Unit] = ???
+  }
+
+  override def createReceiver(config: Config): MqReceiver = new MqReceiver {
+
+    override def receive(maxMsgCount: Int): Future[Seq[(MsgId, String)]] = ???
+
+    override def ack(ids: Seq[MsgId]): Future[Unit] = ???
+  }
+}

--- a/clients/postgres/src/main/scala/mqperf/postgres/PostgresMq.scala
+++ b/clients/postgres/src/main/scala/mqperf/postgres/PostgresMq.scala
@@ -1,11 +1,73 @@
 package mqperf.postgres
 
+import com.typesafe.scalalogging.StrictLogging
+import io.r2dbc.pool.{ConnectionPool, ConnectionPoolConfiguration}
+import io.r2dbc.postgresql.{PostgresqlConnectionConfiguration, PostgresqlConnectionFactory}
+import io.r2dbc.spi.Connection
 import mqperf.{Config, Mq, MqReceiver, MqSender}
+import reactor.core.publisher.Mono
 
+import java.time.Duration
 import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
 
-class PostgresMq(clock: java.time.Clock) extends Mq {
-  override def init(config: Config): Unit = ???
+class PostgresMq(clock: java.time.Clock) extends Mq with StrictLogging {
+
+  private val HostsConfigKey = "hosts"
+
+  override def init(config: Config): Unit = {
+    Try {
+      val connectionFactory = new PostgresqlConnectionFactory(
+        PostgresqlConnectionConfiguration
+          .builder()
+          .host("postgres")
+          .port(5432)
+          .username("mquser")
+          .password("mqpass")
+          .database("mqdb")
+          .build()
+      )
+
+      val poolConfiguration = ConnectionPoolConfiguration
+        .builder(connectionFactory)
+        .maxIdleTime(Duration.ofMillis(1000))
+        .maxSize(10)
+        .minIdle(10)
+        .build()
+
+      val connectionPool = new ConnectionPool(poolConfiguration)
+
+      Mono
+        .usingWhen(
+          connectionPool.create(),
+          (v: Connection) =>
+            Mono
+              .from(
+                v.createStatement(
+                  "CREATE TABLE IF NOT EXISTS jobs(ID UUID PRIMARY KEY, CONTENT TEXT NOT NULL, NEXT_DELIVERY TIMESTAMPTZ NOT NULL)"
+                ).execute()
+              )
+              .map(v => {
+                logger.info(s"Result $v")
+                v
+              })
+              .onErrorResume(ex => {
+                logger.error("Error", ex)
+                Mono.empty()
+              }),
+          (v: Connection) => v.close()
+        )
+        .onErrorResume(ex => {
+          logger.error("Error", ex)
+          Mono.empty()
+        })
+        .thenEmpty(connectionPool.close())
+        .subscribe()
+    } match {
+      case Success(v)  => logger.info(s"PostgresMq initialized $v")
+      case Failure(ex) => logger.error("PostgresMq initialization error", ex)
+    }
+  }
 
   override def cleanUp(config: Config): Unit = ???
 

--- a/clients/postgres/src/main/scala/mqperf/postgres/PostgresMq.scala
+++ b/clients/postgres/src/main/scala/mqperf/postgres/PostgresMq.scala
@@ -50,7 +50,7 @@ class PostgresMq(clock: java.time.Clock) extends Mq with StrictLogging {
       )
     )
 
-    connectionFactory.map(cf => {
+    connectionFactory.foreach(cf => {
       val client: DatabaseClient = DatabaseClient
         .builder()
         .connectionFactory(cf)
@@ -76,7 +76,7 @@ class PostgresMq(clock: java.time.Clock) extends Mq with StrictLogging {
     })
   }
 
-  override def cleanUp(config: Config): Unit = connectionFactory.map(cf => {
+  override def cleanUp(config: Config): Unit = connectionFactory.foreach(cf => {
     val table = config.mqConfig(TableConfigKey)
 
     val client: DatabaseClient = DatabaseClient
@@ -202,7 +202,7 @@ class PostgresMq(clock: java.time.Clock) extends Mq with StrictLogging {
 
     override def ack(ids: Seq[MsgId]): Future[Unit] = ids match {
       case Nil =>
-        Future.successful()
+        Future.successful(())
       case vs =>
         client
           .sql("delete from jobs where id in (:inIds)")

--- a/clients/postgres/src/main/scala/mqperf/postgres/PostgresMq.scala
+++ b/clients/postgres/src/main/scala/mqperf/postgres/PostgresMq.scala
@@ -63,7 +63,7 @@ class PostgresMq(clock: java.time.Clock) extends Mq with StrictLogging {
         .rowsUpdated()
         .flatMap(_ =>
           client
-            .sql("create index if not exists next_delivery_idx on jobs(next_delivery)")
+            .sql(s"create index if not exists next_delivery_idx on $table(next_delivery)")
             .fetch()
             .rowsUpdated()
         )

--- a/clients/postgres/src/main/scala/mqperf/postgres/PostgresMq.scala
+++ b/clients/postgres/src/main/scala/mqperf/postgres/PostgresMq.scala
@@ -57,7 +57,19 @@ class PostgresMq(clock: java.time.Clock) extends Mq with StrictLogging {
     })
   }
 
-  override def cleanUp(config: Config): Unit = ???
+  override def cleanUp(config: Config): Unit = connectionFactory.map(cf => {
+    val client: DatabaseClient = DatabaseClient
+      .builder()
+      .connectionFactory(cf)
+      .namedParameters(true)
+      .build()
+
+    client
+      .sql("drop table if exists jobs")
+      .fetch()
+      .rowsUpdated()
+      .subscribe()
+  })
 
   override def createSender(config: Config): MqSender = new MqSender {
 

--- a/clients/postgres/src/main/scala/mqperf/postgres/PostgresMq.scala
+++ b/clients/postgres/src/main/scala/mqperf/postgres/PostgresMq.scala
@@ -200,15 +200,20 @@ class PostgresMq(clock: java.time.Clock) extends Mq with StrictLogging {
         .asScala
     }
 
-    override def ack(ids: Seq[MsgId]): Future[Unit] =
-      client
-        .sql("delete from jobs where id in (:inIds)")
-        .bind("inIds", ids.asJava)
-        .fetch()
-        .rowsUpdated()
-        .toFuture
-        .asScala
-        .map(_ => ())
+    override def ack(ids: Seq[MsgId]): Future[Unit] = ids match {
+      case Nil =>
+        Future.successful()
+      case vs =>
+        client
+          .sql("delete from jobs where id in (:inIds)")
+          .bind("inIds", vs.asJava)
+          .fetch()
+          .rowsUpdated()
+          .toFuture
+          .asScala
+          .map(_ => ())
+    }
+
 
     override def close(): Future[Unit] = {
       receiverPool

--- a/docker/postgres/docker-compose.yml
+++ b/docker/postgres/docker-compose.yml
@@ -1,21 +1,22 @@
 ---
 version: '2'
 
-volumes:
-  prometheus_data: {}
-  grafana_data: {}
-
 services:
-  postgresmq:
+  postgres:
     image: postgres
-    container_name: 'postgresmq'
+    container_name: 'postgres'
     environment:
       POSTGRES_PASSWORD: defaultPass
+    volumes:
+      - ./init-mqDb.sh:/docker-entrypoint-initdb.d/init-mqDb.sh
+    hostname: postgres
+    ports:
+      - 5432:5432
 
   mqperf:
-    image: softwaremill/mqperf-kafka:latest
+    image: softwaremill/mqperf-postgres:latest
     depends_on:
-      - postgresmq
+      - postgres
     ports:
       - 8080:8080
     hostname: mqperf

--- a/docker/postgres/docker-compose.yml
+++ b/docker/postgres/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     hostname: postgres
     ports:
       - 5432:5432
-    command: ["postgres", "-c", "log_statement=all"]
 
   mqperf:
     image: softwaremill/mqperf-postgres:latest

--- a/docker/postgres/docker-compose.yml
+++ b/docker/postgres/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     hostname: postgres
     ports:
       - 5432:5432
+    command: ["postgres", "-c", "log_statement=all"]
 
   mqperf:
     image: softwaremill/mqperf-postgres:latest

--- a/docker/postgres/docker-compose.yml
+++ b/docker/postgres/docker-compose.yml
@@ -1,0 +1,22 @@
+---
+version: '2'
+
+volumes:
+  prometheus_data: {}
+  grafana_data: {}
+
+services:
+  postgresmq:
+    image: postgres
+    container_name: 'postgresmq'
+    environment:
+      POSTGRES_PASSWORD: defaultPass
+
+  mqperf:
+    image: softwaremill/mqperf-kafka:latest
+    depends_on:
+      - postgresmq
+    ports:
+      - 8080:8080
+    hostname: mqperf
+    container_name: mqperf

--- a/docker/postgres/init-mqDb.sh
+++ b/docker/postgres/init-mqDb.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+	CREATE USER mquser;
+	ALTER USER mquser WITH PASSWORD 'mqpass';
+	CREATE DATABASE mqdb;
+EOSQL
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname mqdb <<-EOSQL
+  GRANT ALL PRIVILEGES ON SCHEMA public TO mquser;
+EOSQL

--- a/postgresMq.http
+++ b/postgresMq.http
@@ -1,0 +1,81 @@
+### /init: "-1" means that value is not used
+
+POST http://localhost:8080/init
+Content-Type: application/json
+
+{
+  "testId": "test",
+  "testLengthSeconds": -1,
+  "msgsPerSecond": -1,
+  "msgSizeBytes": -1,
+  "batchSizeSend": -1,
+  "maxSendInFlight": -1,
+  "batchSizeReceive": -1,
+  "mqConfig": {
+    "host": "postgres",
+    "port": "5432",
+    "table": "jobs"
+  }
+}
+
+### /sender: "-1" means that value is not used
+
+POST http://localhost:8080/start/sender
+Content-Type: application/json
+
+{
+  "testId": "test",
+  "testLengthSeconds": 3,
+  "msgsPerSecond": 100,
+  "msgSizeBytes": 1000,
+  "batchSizeSend": 10,
+  "maxSendInFlight": 1000,
+  "batchSizeReceive": -1,
+  "mqConfig": {
+    "senderPoolSize": "5"
+  }
+}
+
+### /receiver: "-1" means that value is not used
+
+POST http://localhost:8080/start/receiver
+Content-Type: application/json
+
+{
+  "testId": "test",
+  "testLengthSeconds": -1,
+  "msgsPerSecond": -1,
+  "msgSizeBytes": -1,
+  "batchSizeSend": -1,
+  "maxSendInFlight": -1,
+  "batchSizeReceive": 100,
+  "mqConfig": {
+    "receiverPoolSize": "5"
+  }
+}
+
+### /cleanup:  "-1" means that value is not used
+
+POST http://localhost:8080/cleanup
+Content-Type: application/json
+
+{
+  "testId": "test",
+  "testLengthSeconds": -1,
+  "msgsPerSecond": -1,
+  "msgSizeBytes": -1,
+  "batchSizeSend": -1,
+  "maxSendInFlight": -1,
+  "batchSizeReceive": -1,
+  "mqConfig": {
+    "table": "jobs"
+  }
+}
+
+### /in-progress
+
+GET http://localhost:8080/in-progress
+
+### /metrics
+
+GET http://localhost:8080/metrics

--- a/terraform/live/_envcommon/eks.hcl
+++ b/terraform/live/_envcommon/eks.hcl
@@ -13,6 +13,8 @@ inputs = {
   org         = "SML"
   environment = get_env("CLUSTER_NAME")
 
+  azs = ["eu-central-1a"]
+
   eks_cluster_node_groups = {
     controllers-pool = {
       min_size       = 1


### PR DESCRIPTION
Implementation of PostgresMq client

Client uses [r2dbc-postgres](https://github.com/pgjdbc/r2dbc-postgresql) driver, implenetation of [r2dbc-spi](https://github.com/r2dbc/r2dbc-spi). SQL queries are executed using Spring `DatabaseClient` from [spring-data-r2dbc project](https://docs.spring.io/spring-data/r2dbc/docs/1.5.6/reference/html/).

Each sender and receiver creates its own connection pool.

On `/init` endpoint client prepares the whole insert query because r2dbc does not support inserting many values in one insert. R2dbc batching will add each value with dedicated insert.

Spring `DatabaseClient` is used because native r2dbc does not support ` in` condition clause. Additionally it simplifies transaction management and r2dbc usage. There is more recent version of [spring-data-r2dbc project](https://spring.io/projects/spring-data-r2dbc) but it requires jdk-17 to work. 

Required fields in mqConfig section:
* `/init` endpoint:
```json
"mqConfig": {
  "host": "postgres",
  "port": "5432",
  "table": "jobs"
}
```
* `/sender` endpoint:
```json
"mqConfig": {
  "senderPoolSize": "5"
}
```
* `/receiver` endpoint:
```json
"mqConfig": {
  "senderPoolSize": "5"
}
```
* `/cleanup` endpoint:
```json
"mqConfig": {
  "table": "jobs"
}
```
Full examples are in `postgreMq.http` file.




