### PR TITLE
Adds new configs: sendersNumber, senderConcurrency, receiversNumber, receiverConcurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,10 @@ The structure of the config JSON is:
   "msgsPerProcessInSecond": 10,
   "msgSizeBytes": 100,
   "batchSizeSend": 1,
+  "sendersNumber": 1,
   "senderConcurrency": 4,
   "batchSizeReceive": 1,
+  "receiversNumber": 1,
   "receiverConcurrency": 4,
   "mqConfig":{  
     
@@ -353,7 +355,7 @@ Confluent's control center (available at `http://localhost:9021`), and the mqper
 To init, then start the sender/receiver, use the following commands, using appropriate endpoints:
 
 ```bash
-curl -XPOST -d'{"testId":"test","testLengthSeconds":10,"msgsPerProcessInSecond":10,"msgSizeBytes":100,"batchSizeSend":1,"senderConcurrency":200,"batchSizeReceive":1,"receiverConcurrency":200,"mqConfig":{"hosts":"broker:29092","topic":"mqperf-test","acks":"-1","groupId":"mqperf","commitMs":"1000","partitions":"10","replicationFactor":"1"}}' http://localhost:8080/init
+curl -XPOST -d'{"testId":"test","testLengthSeconds":10,"msgsPerProcessInSecond":10,"msgSizeBytes":100,"batchSizeSend":1,"sendersNumber": 1,"senderConcurrency":200,"batchSizeReceive":1,"receiversNumber": 1,"receiverConcurrency":200,"mqConfig":{"hosts":"broker:29092","topic":"mqperf-test","acks":"-1","groupId":"mqperf","commitMs":"1000","partitions":"10","replicationFactor":"1"}}' http://localhost:8080/init
 ```
 
 ## Working with AWS cluster

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Confluent's control center (available at `http://localhost:9021`), and the mqper
 To init, then start the sender/receiver, use the following commands, using appropriate endpoints:
 
 ```bash
-curl -XPOST -d'{"testId":"test","testLengthSeconds":10,"msgsPerSecond":10,"msgSizeBytes":100,"batchSizeSend":1,"senderConcurrency":200,"batchSizeReceive":1,"receiverConcurrency":200,"mqConfig":{"hosts":"broker:29092","topic":"mqperf-test","acks":"-1","groupId":"mqperf","commitMs":"1000","partitions":"10","replicationFactor":"1"}}' http://localhost:8080/init
+curl -XPOST -d'{"testId":"test","testLengthSeconds":10,"msgsPerProcessInSecond":10,"msgSizeBytes":100,"batchSizeSend":1,"senderConcurrency":200,"batchSizeReceive":1,"receiverConcurrency":200,"mqConfig":{"hosts":"broker:29092","topic":"mqperf-test","acks":"-1","groupId":"mqperf","commitMs":"1000","partitions":"10","replicationFactor":"1"}}' http://localhost:8080/init
 ```
 
 ## Working with AWS cluster

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Confluent's control center (available at `http://localhost:9021`), and the mqper
 To init, then start the sender/receiver, use the following commands, using appropriate endpoints:
 
 ```bash
-curl -XPOST -d'{"testId":"test","testLengthSeconds":10,"msgsPerSecond":10,"msgSizeBytes":100,"batchSizeSend":1,"senderConcurrency":4,"batchSizeReceive":1,"receiverConcurrency":4,"mqConfig":{"hosts":"broker:29092","topic":"mqperf-test","acks":"-1","groupId":"mqperf","commitMs":"1000","partitions":"10","replicationFactor":"1"}}' http://localhost:8080/init
+curl -XPOST -d'{"testId":"test","testLengthSeconds":10,"msgsPerSecond":10,"msgSizeBytes":100,"batchSizeSend":1,"senderConcurrency":200,"batchSizeReceive":1,"receiverConcurrency":200,"mqConfig":{"hosts":"broker:29092","topic":"mqperf-test","acks":"-1","groupId":"mqperf","commitMs":"1000","partitions":"10","replicationFactor":"1"}}' http://localhost:8080/init
 ```
 
 ## Working with AWS cluster

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ The structure of the config JSON is:
 {
   "testId": "test",
   "testLengthSeconds": 10,
-  "msgsPerSecond": 10,
+  "msgsPerProcessInSecond": 10,
   "msgSizeBytes": 100,
   "batchSizeSend": 1,
   "senderConcurrency": 4,

--- a/README.md
+++ b/README.md
@@ -321,8 +321,9 @@ The structure of the config JSON is:
   "msgsPerSecond": 10,
   "msgSizeBytes": 100,
   "batchSizeSend": 1,
+  "senderConcurrency": 4,
   "batchSizeReceive": 1,
-  "maxSendInFlight": 1,
+  "receiverConcurrency": 4,
   "mqConfig":{  
     
   }
@@ -352,7 +353,7 @@ Confluent's control center (available at `http://localhost:9021`), and the mqper
 To init, then start the sender/receiver, use the following commands, using appropriate endpoints:
 
 ```bash
-curl -XPOST -d'{"testId":"test","testLengthSeconds":10,"msgsPerSecond":10,"msgSizeBytes":100,"batchSizeSend":1,"batchSizeReceive":1,"maxSendInFlight":1,"mqConfig":{"hosts":"broker:29092","topic":"mqperf-test","acks":"-1","groupId":"mqperf","commitMs":"1000","partitions":"10","replicationFactor":"1"}}' http://localhost:8080/init
+curl -XPOST -d'{"testId":"test","testLengthSeconds":10,"msgsPerSecond":10,"msgSizeBytes":100,"batchSizeSend":1,"senderConcurrency":4,"batchSizeReceive":1,"receiverConcurrency":4,"mqConfig":{"hosts":"broker:29092","topic":"mqperf-test","acks":"-1","groupId":"mqperf","commitMs":"1000","partitions":"10","replicationFactor":"1"}}' http://localhost:8080/init
 ```
 
 ## Working with AWS cluster

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val core: Project = (project in file("clients/core"))
       "com.softwaremill.sttp.tapir" %% "tapir-netty-server" % tapirVersion,
       "com.softwaremill.sttp.tapir" %% "tapir-prometheus-metrics" % tapirVersion,
       "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % tapirVersion,
-      "org.typelevel" %% "cats-effect" % "3.5-6581dc4",
+      "org.typelevel" %% "cats-effect" % "3.4.4",
       "org.typelevel" %% "cats-core" % "2.9.0",
       scalaTest
     )

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,8 @@ lazy val core: Project = (project in file("clients/core"))
       "com.softwaremill.sttp.tapir" %% "tapir-netty-server" % tapirVersion,
       "com.softwaremill.sttp.tapir" %% "tapir-prometheus-metrics" % tapirVersion,
       "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % tapirVersion,
+      "org.typelevel" %% "cats-effect" % "3.5-6581dc4",
+      "org.typelevel" %% "cats-core" % "2.9.0",
       scalaTest
     )
   )

--- a/clients/core/src/main/scala/mqperf/Config.scala
+++ b/clients/core/src/main/scala/mqperf/Config.scala
@@ -16,6 +16,7 @@ case class Config(
     msgSizeBytes: Int,
     batchSizeSend: Int,
     msgsPerProcessInSecond: Int,
+    sendersNumbers: Int,
     senderConcurrency: Int,
     batchSizeReceive: Int,
     receiverConcurrency: Int,

--- a/clients/core/src/main/scala/mqperf/Config.scala
+++ b/clients/core/src/main/scala/mqperf/Config.scala
@@ -19,6 +19,7 @@ case class Config(
     sendersNumbers: Int,
     senderConcurrency: Int,
     batchSizeReceive: Int,
+    receiversNumbers: Int,
     receiverConcurrency: Int,
     mqConfig: Map[String, String]
 )

--- a/clients/core/src/main/scala/mqperf/Config.scala
+++ b/clients/core/src/main/scala/mqperf/Config.scala
@@ -4,7 +4,7 @@ package mqperf
   * implementation.
   *
   * A sender should send up to [[msgsPerSecond]] messages, in batches of [[batchSizeSend]] messages, where each message has [[msgSizeBytes]]
-  * bytes. At most [[maxSendInFlight]] messages should be in flight (sent initiated, but not yet complete) at any given time.
+  * bytes. One sender sends at most [[senderConcurrency]] concurrent batches.
   *
   * A receiver should receive messages in batches of up to [[batchSizeReceive]]
   */
@@ -15,7 +15,7 @@ case class Config(
     msgSizeBytes: Int,
     batchSizeSend: Int,
     batchSizeReceive: Int,
-    maxSendInFlight: Int,
+    senderConcurrency: Int,
     mqConfig: Map[String, String]
 )
 

--- a/clients/core/src/main/scala/mqperf/Config.scala
+++ b/clients/core/src/main/scala/mqperf/Config.scala
@@ -6,7 +6,7 @@ package mqperf
   * A sender should send up to [[msgsPerSecond]] messages, in batches of [[batchSizeSend]] messages, where each message has [[msgSizeBytes]]
   * bytes. One sender sends at most [[senderConcurrency]] concurrent batches.
   *
-  * A receiver should receive messages in batches of up to [[batchSizeReceive]]. One sender receives at most [[receiverConcurrency]]
+  * A receiver should receive messages in batches of up to [[batchSizeReceive]]. One receiver receives at most [[receiverConcurrency]]
   * concurrent batches.
   */
 case class Config(

--- a/clients/core/src/main/scala/mqperf/Config.scala
+++ b/clients/core/src/main/scala/mqperf/Config.scala
@@ -6,7 +6,8 @@ package mqperf
   * A sender should send up to [[msgsPerSecond]] messages, in batches of [[batchSizeSend]] messages, where each message has [[msgSizeBytes]]
   * bytes. One sender sends at most [[senderConcurrency]] concurrent batches.
   *
-  * A receiver should receive messages in batches of up to [[batchSizeReceive]]
+  * A receiver should receive messages in batches of up to [[batchSizeReceive]]. One sender receives at most [[receiverConcurrency]]
+  * concurrent batches.
   */
 case class Config(
     testId: String,
@@ -14,8 +15,9 @@ case class Config(
     msgsPerSecond: Int,
     msgSizeBytes: Int,
     batchSizeSend: Int,
-    batchSizeReceive: Int,
     senderConcurrency: Int,
+    batchSizeReceive: Int,
+    receiverConcurrency: Int,
     mqConfig: Map[String, String]
 )
 

--- a/clients/core/src/main/scala/mqperf/Config.scala
+++ b/clients/core/src/main/scala/mqperf/Config.scala
@@ -3,9 +3,10 @@ package mqperf
 /** Describes a test run (identified by [[testId]]). The test should run for [[testLengthSeconds]], passing the [[mqConfig]] to the mq
   * implementation.
   *
-  * A sender will send up to [[msgsPerProcessInSecond]] messages per process per second. Number of concurrent processes is equal to [[senderConcurrency]].
-  * In other words sender should send up to [[senderConcurrency]] * [[msgsPerProcessInSecond]] messages, in batches of [[batchSizeSend]] messages.
-  * Each message has [[msgSizeBytes]] bytes.
+  * A sender node will start [[sendersNumber]] instances of mqSenders. Each mqSender will send up to [[msgsPerProcessInSecond]] messages per
+  * concurrent process per second. Number of concurrent processes is equal to [[senderConcurrency]]. In other words sender node should send
+  * up to [[sendersNumber]] * [[senderConcurrency]] * [[msgsPerProcessInSecond]] messages, in batches of [[batchSizeSend]] messages. Each
+  * message has [[msgSizeBytes]] bytes.
   *
   * A receiver should receive messages in batches of up to [[batchSizeReceive]]. One receiver receives at most [[receiverConcurrency]]
   * concurrent batches.
@@ -16,11 +17,10 @@ case class Config(
     msgSizeBytes: Int,
     batchSizeSend: Int,
     msgsPerProcessInSecond: Int,
-    sendersNumbers: Int,
+    sendersNumber: Int,
     senderConcurrency: Int,
     batchSizeReceive: Int,
     receiversNumbers: Int,
     receiverConcurrency: Int,
     mqConfig: Map[String, String]
 )
-

--- a/clients/core/src/main/scala/mqperf/Config.scala
+++ b/clients/core/src/main/scala/mqperf/Config.scala
@@ -3,8 +3,9 @@ package mqperf
 /** Describes a test run (identified by [[testId]]). The test should run for [[testLengthSeconds]], passing the [[mqConfig]] to the mq
   * implementation.
   *
-  * A sender should send up to [[msgsPerSecond]] messages, in batches of [[batchSizeSend]] messages, where each message has [[msgSizeBytes]]
-  * bytes. One sender sends at most [[senderConcurrency]] concurrent batches.
+  * A sender will send up to [[msgsPerProcessInSecond]] messages per process per second. Number of concurrent processes is equal to [[senderConcurrency]].
+  * In other words sender should send up to [[senderConcurrency]] * [[msgsPerProcessInSecond]] messages, in batches of [[batchSizeSend]] messages.
+  * Each message has [[msgSizeBytes]] bytes.
   *
   * A receiver should receive messages in batches of up to [[batchSizeReceive]]. One receiver receives at most [[receiverConcurrency]]
   * concurrent batches.
@@ -12,9 +13,9 @@ package mqperf
 case class Config(
     testId: String,
     testLengthSeconds: Int,
-    msgsPerSecond: Int,
     msgSizeBytes: Int,
     batchSizeSend: Int,
+    msgsPerProcessInSecond: Int,
     senderConcurrency: Int,
     batchSizeReceive: Int,
     receiverConcurrency: Int,

--- a/clients/core/src/main/scala/mqperf/Config.scala
+++ b/clients/core/src/main/scala/mqperf/Config.scala
@@ -8,8 +8,8 @@ package mqperf
   * up to [[sendersNumber]] * [[senderConcurrency]] * [[msgsPerProcessInSecond]] messages, in batches of [[batchSizeSend]] messages. Each
   * message has [[msgSizeBytes]] bytes.
   *
-  * A receiver should receive messages in batches of up to [[batchSizeReceive]]. One receiver receives at most [[receiverConcurrency]]
-  * concurrent batches.
+  * A receiver node will start [[receiversNumber]] instances of mqReceiver. Each mqReceiver will receive messages in batches of up to
+  * [[batchSizeReceive]]. One receiver receives at most [[receiverConcurrency]] concurrent batches.
   */
 case class Config(
     testId: String,
@@ -20,7 +20,7 @@ case class Config(
     sendersNumber: Int,
     senderConcurrency: Int,
     batchSizeReceive: Int,
-    receiversNumbers: Int,
+    receiversNumber: Int,
     receiverConcurrency: Int,
     mqConfig: Map[String, String]
 )

--- a/clients/core/src/main/scala/mqperf/Mq.scala
+++ b/clients/core/src/main/scala/mqperf/Mq.scala
@@ -8,9 +8,9 @@ trait Mq {
 
   /** returns new instance of MqSenderFactory each time */
   def createSenderFactory(config: Config): MqSenderFactory
-  def receiverFactory(config: Config): MqReceiverFactory = ???
 
-  def createReceiver(config: Config): MqReceiver
+  /** returns new instance of MqReceiverFactory each time */
+  def createReceiverFactory(config: Config): MqReceiverFactory
 }
 
 trait MqSenderFactory {

--- a/clients/core/src/main/scala/mqperf/Mq.scala
+++ b/clients/core/src/main/scala/mqperf/Mq.scala
@@ -5,8 +5,17 @@ import scala.concurrent.Future
 trait Mq {
   def init(config: Config): Unit
   def cleanUp(config: Config): Unit
+
+  //TODO: to discuss: should this function for multiple calls return the same instance of `MqSenderFactory`?
+  def senderFactory(config: Config): MqSenderFactory = ???
+
+  @Deprecated
   def createSender(config: Config): MqSender
   def createReceiver(config: Config): MqReceiver
+}
+
+trait MqSenderFactory {
+  def createSender(): MqSender
 }
 
 trait MqSender {

--- a/clients/core/src/main/scala/mqperf/Mq.scala
+++ b/clients/core/src/main/scala/mqperf/Mq.scala
@@ -15,6 +15,10 @@ trait Mq {
 
 trait MqSenderFactory {
   def createSender(): MqSender
+
+  /** close resources which are shared between senders within one factory */
+  def close(): Future[Unit] = Future.successful(())
+
 }
 
 trait MqSender {
@@ -24,6 +28,9 @@ trait MqSender {
 
 trait MqReceiverFactory {
   def createReceiver(): MqReceiver
+
+  /** close resources which are shared between receivers within one factory */
+  def close(): Future[Unit] = Future.successful(())
 }
 
 trait MqReceiver {

--- a/clients/core/src/main/scala/mqperf/Mq.scala
+++ b/clients/core/src/main/scala/mqperf/Mq.scala
@@ -8,6 +8,7 @@ trait Mq {
 
   //TODO: to discuss: should this function for multiple calls return the same instance of `MqSenderFactory`?
   def senderFactory(config: Config): MqSenderFactory = ???
+  def receiverFactory(config: Config): MqReceiverFactory = ???
 
   @Deprecated
   def createSender(config: Config): MqSender
@@ -21,6 +22,10 @@ trait MqSenderFactory {
 trait MqSender {
   def send(msgs: Seq[String]): Future[Unit]
   def close(): Future[Unit] = Future.successful(())
+}
+
+trait MqReceiverFactory {
+  def createReceiver(): MqReceiver
 }
 
 trait MqReceiver {

--- a/clients/core/src/main/scala/mqperf/Mq.scala
+++ b/clients/core/src/main/scala/mqperf/Mq.scala
@@ -6,12 +6,10 @@ trait Mq {
   def init(config: Config): Unit
   def cleanUp(config: Config): Unit
 
-  //TODO: to discuss: should this function for multiple calls return the same instance of `MqSenderFactory`?
-  def senderFactory(config: Config): MqSenderFactory = ???
+  /** returns new instance of MqSenderFactory each time */
+  def createSenderFactory(config: Config): MqSenderFactory
   def receiverFactory(config: Config): MqReceiverFactory = ???
 
-  @Deprecated
-  def createSender(config: Config): MqSender
   def createReceiver(config: Config): MqReceiver
 }
 

--- a/clients/core/src/main/scala/mqperf/Receiver.scala
+++ b/clients/core/src/main/scala/mqperf/Receiver.scala
@@ -20,9 +20,10 @@ class Receiver(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
   private val FinishWhenNoMessagesAfter = 60.seconds
 
   def run(): Future[Unit] = {
+    val receiverFactory = mq.createReceiverFactory(config)
     Future.sequence {
       (1 to config.receiversNumbers).map(_ => {
-        mq.receiverFactory(config).createReceiver()
+        receiverFactory.createReceiver()
       }) // prepare n receivers (n = receiversNumbers)
         .map(receiver => { // run iteration for each receiver on a separate future and close the connection afterwards
         runIterations(receiver)

--- a/clients/core/src/main/scala/mqperf/Receiver.scala
+++ b/clients/core/src/main/scala/mqperf/Receiver.scala
@@ -20,8 +20,15 @@ class Receiver(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
   private val FinishWhenNoMessagesAfter = 60.seconds
 
   def run(): Future[Unit] = {
-    val mqReceiver = mq.receiverFactory(config).createReceiver()
-    runIterations(mqReceiver).flatMap(_ => mqReceiver.close())
+    Future.sequence {
+      (1 to config.receiversNumbers).map(_ => {
+        mq.receiverFactory(config).createReceiver()
+      }) // prepare n receivers (n = receiversNumbers)
+        .map(receiver => { // run iteration for each receiver on a separate future and close the connection afterwards
+        runIterations(receiver)
+          .flatMap(_ => receiver.close())
+      })
+    }.map(_ => ())
   }
 
   private def runIterations(mqReceiver: MqReceiver): Future[Unit] = {
@@ -51,6 +58,9 @@ class Receiver(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
             case 0 => receive(lastActivity)
             case _ => receive(clock.millis())
           }
+          .flatMap(lastActivitiesSeq => {
+            receive(lastActivitiesSeq.max)
+          })
       }
     }
 

--- a/clients/core/src/main/scala/mqperf/Receiver.scala
+++ b/clients/core/src/main/scala/mqperf/Receiver.scala
@@ -20,7 +20,7 @@ class Receiver(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
   private val FinishWhenNoMessagesAfter = 60.seconds
 
   def run(): Future[Unit] = {
-    val mqReceiver = mq.createReceiver(config)
+    val mqReceiver = mq.receiverFactory(config).createReceiver()
     runIterations(mqReceiver).flatMap(_ => mqReceiver.close())
   }
 

--- a/clients/core/src/main/scala/mqperf/Receiver.scala
+++ b/clients/core/src/main/scala/mqperf/Receiver.scala
@@ -22,7 +22,7 @@ class Receiver(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
   def run(): Future[Unit] = {
     val receiverFactory = mq.createReceiverFactory(config)
     Future.sequence {
-      (1 to config.receiversNumbers).map(_ => {
+      (1 to config.receiversNumber).map(_ => {
         receiverFactory.createReceiver()
       }) // prepare n receivers (n = receiversNumbers)
         .map(receiver => { // run iteration for each receiver on a separate future and close the connection afterwards

--- a/clients/core/src/main/scala/mqperf/Receiver.scala
+++ b/clients/core/src/main/scala/mqperf/Receiver.scala
@@ -32,6 +32,9 @@ class Receiver(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
               .flatMap(_ => receiver.close())
           })
       }
+      .flatMap { _ =>
+        receiverFactory.close()
+      }
       .map(_ => ())
   }
 

--- a/clients/core/src/main/scala/mqperf/Receiver.scala
+++ b/clients/core/src/main/scala/mqperf/Receiver.scala
@@ -7,6 +7,7 @@ import java.time.Clock
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
+import scala.util.Failure
 
 class Receiver(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
 
@@ -45,6 +46,9 @@ class Receiver(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
           .flatMap {
             case 0 => receive(lastActivity)
             case _ => receive(clock.millis())
+          }
+          .andThen {
+            case Failure(ex) => logger.error("Receiving iteration failure", ex)
           }
       }
     }

--- a/clients/core/src/main/scala/mqperf/Receiver.scala
+++ b/clients/core/src/main/scala/mqperf/Receiver.scala
@@ -55,7 +55,7 @@ class Receiver(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
         (1 to receiverConcurrency).map { _ => receive(clock.millis()) }
       )
       .andThen {
-        case Success(_) => logger.info(s"No messages received for ${FinishWhenNoMessagesAfter.toSeconds}s, stopping")
+        case Success(_)  => logger.info(s"No messages received for ${FinishWhenNoMessagesAfter.toSeconds}s, stopping")
         case Failure(ex) => logger.error("Receiving iteration failure", ex)
       }
       .map(_ => ())

--- a/clients/core/src/main/scala/mqperf/Sender.scala
+++ b/clients/core/src/main/scala/mqperf/Sender.scala
@@ -21,15 +21,6 @@ class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
     val messageLatencyHistogram: Histogram.Child = Metrics.Sender.messageLatencyHistogram.labels(testIdLabelValue)
   }
 
-  /*
-    sent - number of messages already sent
-    permits - number of messages which sender is allowed to send
-    currentIteration - number of iteration, 1 iteration lasts 1 second
-    nextIterationHook - allows sender to wait for next iteration without thread-blocking. If Deferred will evaluate to
-      false sender will start nextIteration, otherwise it will finish sending.
-   */
-  case class State(sent: Long, permits: Long, currentIteration: Int, nextIterationHook: Deferred[IO, Boolean])
-
   def run(): Future[Unit] = {
     val mqSender = mq.createSender(config)
     logger.info("Starting sender...")

--- a/clients/core/src/main/scala/mqperf/Sender.scala
+++ b/clients/core/src/main/scala/mqperf/Sender.scala
@@ -1,20 +1,19 @@
 package mqperf
 
+import cats.effect._
+import cats.effect.unsafe.IORuntime
+import cats.implicits._
 import com.typesafe.scalalogging.StrictLogging
 import io.prometheus.client.{Counter, Histogram}
 
 import java.time.Clock
-import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicInteger
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.{ExecutionContext, Future, blocking}
-import scala.util.Failure
 
 class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
 
+  implicit val ioRuntime: IORuntime = cats.effect.unsafe.IORuntime.global
   private val messagesPool = RandomMessagesPool(config.msgSizeBytes)
-  private val loopEc = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())
 
   private object LocalMetrics {
     private val testIdLabelValue = config.testId
@@ -22,61 +21,106 @@ class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
     val messageLatencyHistogram: Histogram.Child = Metrics.Sender.messageLatencyHistogram.labels(testIdLabelValue)
   }
 
+  /*
+    sent - number of messages already sent
+    permits - number of messages which sender is allowed to send
+    currentIteration - number of iteration, 1 iteration lasts 1 second
+    nextIterationHook - allows sender to wait for next iteration without thread-blocking. If Deferred will evaluate to
+      false sender will start nextIteration, otherwise it will finish sending.
+   */
+  case class State(sent: Long, permits: Long, currentIteration: Int, nextIterationHook: Deferred[IO, Boolean])
+
   def run(): Future[Unit] = {
     val mqSender = mq.createSender(config)
-    val end = clock.millis() + config.testLengthSeconds.seconds.toMillis
-    runIterations(mqSender, end)
-      .map { _ =>
-        logger.info("Sending done, waiting for all messages to be flushed ...")
-        Thread.sleep(3.seconds.toMillis)
-      }
-      .flatMap(_ => mqSender.close())
+
+    val senderRun = runParallel(mqSender, config.senderConcurrency) >>
+      IO(logger.info("Sending done, waiting for all messages to be flushed ...")) >>
+      IO.sleep(3.seconds) >>
+      IO.fromFuture(IO(mqSender.close()))
+
+    senderRun
+      .handleError(e => logger.error("Sender failed", e))
+      .unsafeToFuture()
   }
 
-  private def runIterations(mqSender: MqSender, testEnd: Long): Future[Unit] = {
+  private def runParallel(mqSender: MqSender, senderConcurrency: Int): IO[Unit] = {
     val batchSize = config.batchSizeSend
-    val sentMessages = new AtomicInteger(0)
-    val permits = new AtomicInteger(0)
 
-    def send(): Future[Unit] = {
-      if (clock.millis() >= testEnd) {
-        Future.successful(())
-      } else if (sentMessages.get() < permits.get()) {
-        val sendStart = clock.millis()
-        sentMessages.addAndGet(batchSize)
-        mqSender
-          .send(nextMessagesBatch(batchSize))
-          .map { _ =>
-            LocalMetrics.messageCounter.inc(batchSize.toDouble)
-            LocalMetrics.messageLatencyHistogram.observe((clock.millis() - sendStart).toDouble)
+    def sendRunner(state: Ref[IO, State], iterationNo: Int = 0): IO[Unit] = {
+      def iteration(state: Ref[IO, State]): IO[Unit] = {
+        state.get.flatMap(s =>
+          if (s.sent >= s.permits) {
+            IO.unit
           }
-          .flatMap(_ => send())
-      } else {
-        // do nothing, just wait for either: increasing of the permits or the test end
-        send()
+          else {
+            for {
+              sendStart <- IO(clock.millis())
+              _ <- IO.fromFuture(IO(mqSender.send(nextMessagesBatch(batchSize))))
+              _ <- state.update { s => s.copy(sent = s.sent + batchSize) }
+              _ <- IO {
+                LocalMetrics.messageCounter.inc(batchSize.toDouble)
+                LocalMetrics.messageLatencyHistogram.observe((clock.millis() - sendStart).toDouble)
+              }
+              result <- iteration(state)
+            } yield result
+          }
+        )
+        .handleErrorWith{ e =>
+          IO(logger.error(s"Sender iteration[$iterationNo] failed ", e)) >>
+            iteration(state)
+        }
+      }
+
+      state.get.flatMap(s => {
+        if(iterationNo < s.currentIteration) {
+          iteration(state) >> sendRunner(state, iterationNo + 1)
+        }
+        else {
+          s.nextIterationHook.get.flatMap(isTestEnd => {
+            if (isTestEnd) IO.unit
+            else iteration(state) >> sendRunner(state, iterationNo + 1)
+          })
+        }
+      })
+    }
+
+    def loop(until: Long, state: Ref[IO, State], iterationNo: Int = 0): IO[Unit] = {
+      if (clock.millis() >= until) {
+        state
+          .get
+          .flatMap(_.nextIterationHook.complete(true))
+          .void
+      }
+      else {
+        for {
+          nextIterationH <- Deferred[IO, Boolean]
+          _              <- state.get.flatMap(_.nextIterationHook.complete(false))
+          addedPermits   <- state.modify(s => {
+                              val p = newPermits(s.sent, s.permits)
+                              s.copy(
+                                permits = s.permits + p,
+                                currentIteration = s.currentIteration + 1,
+                                nextIterationHook = nextIterationH
+                              ) -> p
+                            })
+          _              <- IO(logger.info(s"Messages to send: $addedPermits (concurrency=${config.senderConcurrency})"))
+          _              <- IO.sleep(1.second)
+          result         <- loop(until, state, iterationNo + 1)
+        } yield result
       }
     }
 
-    // increases permits number every second
-    Future {
-      while (clock.millis() < testEnd) {
-        val startTimestamp = clock.millis()
-        permits.addAndGet(config.msgsPerSecond)
-        logger.info(s"Messages to send: ${config.msgsPerSecond} (concurrency=${config.senderConcurrency})")
-        val endTimestamp = clock.millis()
-        Thread.sleep(Math.max(0, 1.second.toMillis - (endTimestamp - startTimestamp)))
-      }
-    }(loopEc)
+    def newPermits(sent: Long, permits: Long) = {
+      if (permits - sent > config.msgsPerSecond) 0
+      else config.msgsPerSecond
+    }
 
-    val senderConcurrency = config.senderConcurrency
-    Future
-      .sequence(
-        (1 to senderConcurrency).map { _ => send() }
-      )
-      .andThen { case Failure(ex) =>
-        logger.error("Sending iteration failure", ex)
-      }
-      .map(_ => ())
+    for {
+      initHook  <- Deferred[IO, Boolean]
+      initState <- Ref.of[IO, State](State(0, 0, 0, initHook))
+      testEnd   <- IO(clock.millis() + config.testLengthSeconds.seconds.toMillis)
+      runners   <- (loop(testEnd, initState) :: (1 to senderConcurrency).map(_ => sendRunner(initState)).toList).parSequence.void
+    } yield runners
   }
 
   private def nextMessagesBatch(batchSize: Int): Seq[String] = {

--- a/clients/core/src/main/scala/mqperf/Sender.scala
+++ b/clients/core/src/main/scala/mqperf/Sender.scala
@@ -41,9 +41,8 @@ class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
       }
       .parSequence
       .flatMap { _ =>
-        IO(mqSenderFactory.close())
+        IO.fromFuture(IO(mqSenderFactory.close()))
       }
-      .void
       .unsafeToFuture()
   }
 

--- a/clients/core/src/main/scala/mqperf/Sender.scala
+++ b/clients/core/src/main/scala/mqperf/Sender.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future, blocking}
+import scala.util.Failure
 
 class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
 
@@ -62,6 +63,9 @@ class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
       .sequence(
         (1 to senderConcurrency).map { _ => send() }
       )
+      .andThen{
+        case Failure(ex) => logger.error("Sending iteration failure", ex)
+      }
       .map(_ => ())
   }
 

--- a/clients/core/src/main/scala/mqperf/Sender.scala
+++ b/clients/core/src/main/scala/mqperf/Sender.scala
@@ -63,10 +63,8 @@ class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
         val startTimestamp = clock.millis()
         permits.addAndGet(config.msgsPerSecond)
         logger.info(s"Messages to send: ${config.msgsPerSecond} (concurrency=${config.senderConcurrency})")
-        blocking {
-          val endTimestamp = clock.millis()
-          Thread.sleep(Math.max(0, 1.second.toMillis - (endTimestamp - startTimestamp)))
-        }
+        val endTimestamp = clock.millis()
+        Thread.sleep(Math.max(0, 1.second.toMillis - (endTimestamp - startTimestamp)))
       }
     }(loopEc)
 

--- a/clients/core/src/main/scala/mqperf/Sender.scala
+++ b/clients/core/src/main/scala/mqperf/Sender.scala
@@ -64,8 +64,8 @@ class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
       .sequence(
         (1 to senderConcurrency).map { _ => send() }
       )
-      .andThen{
-        case Failure(ex) => logger.error("Sending iteration failure", ex)
+      .andThen { case Failure(ex) =>
+        logger.error("Sending iteration failure", ex)
       }
       .map(_ => ())
   }

--- a/clients/core/src/main/scala/mqperf/Sender.scala
+++ b/clients/core/src/main/scala/mqperf/Sender.scala
@@ -40,6 +40,9 @@ class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
         senderProgram(id).handleError(e => logger.error(s"Sender[$id] failed", e))
       }
       .parSequence
+      .flatMap { _ =>
+        IO(mqSenderFactory.close())
+      }
       .void
       .unsafeToFuture()
   }

--- a/clients/core/src/main/scala/mqperf/Sender.scala
+++ b/clients/core/src/main/scala/mqperf/Sender.scala
@@ -22,7 +22,7 @@ class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
   }
 
   def run(): Future[Unit] = {
-    val mqSender = mq.createSender(config)
+    val mqSender = mq.senderFactory(config).createSender()
     logger.info("Starting sender...")
 
     val senderRun = runParallel(mqSender, config.senderConcurrency) >>

--- a/clients/core/src/main/scala/mqperf/Sender.scala
+++ b/clients/core/src/main/scala/mqperf/Sender.scala
@@ -29,7 +29,7 @@ class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
         while (clock.millis() < end) {
           val iterationStart = clock.millis()
           logger.info(s"Messages to send: ${config.msgsPerSecond} (concurrency=${config.senderConcurrency})")
-          runIteration(mqSender)
+          runIterations(mqSender)
 
           val iterationEnd = clock.millis()
           Thread.sleep(math.max(0, 1.second.toMillis - (iterationEnd - iterationStart)))
@@ -41,7 +41,7 @@ class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
     }.flatMap(_ => mqSender.close())
   }
 
-  private def runIteration(mqSender: MqSender): Future[Unit] = {
+  private def runIterations(mqSender: MqSender): Future[Unit] = {
     val batchSize = config.batchSizeSend
     val sentMessages = new AtomicInteger(0)
 

--- a/clients/core/src/main/scala/mqperf/Sender.scala
+++ b/clients/core/src/main/scala/mqperf/Sender.scala
@@ -6,8 +6,8 @@ import io.prometheus.client.{Counter, Histogram}
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Future, blocking}
-import scala.util.{Failure, Success}
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future, blocking}
 
 class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
 
@@ -24,44 +24,49 @@ class Sender(config: Config, mq: Mq, clock: Clock) extends StrictLogging {
 
     Future {
       blocking {
-        val start = clock.millis()
-        val end = start + config.testLengthSeconds * 1000L
-
-        val permits = new AtomicInteger(config.maxSendInFlight)
-        val batchSize = config.batchSizeSend
-
+        val end = clock.millis() + config.testLengthSeconds.seconds.toMillis
         while (clock.millis() < end) {
-          val iterationStart = clock.millis()
-          // we send at most `config.msgsPerSecond` messages, but no more than the number of available permits
-          val msgsToSend = math.min(config.msgsPerSecond, permits.getAndUpdate(p => math.max(0, p - config.msgsPerSecond)))
-          logger.info(s"Messages to send: $msgsToSend")
-          val batches = msgsToSend / batchSize
-          (1 to batches).foreach { _ =>
-            val sendStart = clock.millis()
-            mqSender.send(nextMessagesBatch()).onComplete { result =>
-              permits.addAndGet(batchSize)
-              LocalMetrics.messageCounter.inc(batchSize.toDouble)
-              LocalMetrics.messageLatencyHistogram.observe((clock.millis() - sendStart).toDouble)
-              result match {
-                case Failure(t) => logger.error("Exception when sending a batch of messages", t)
-                case Success(_) =>
-              }
-            }
-          }
-
-          val iterationEnd = clock.millis()
-          // a whole iteration should take at least a second
-          Thread.sleep(math.max(0, 1000L - (iterationEnd - iterationStart)))
+          logger.info(s"Messages to send: ${config.msgsPerSecond} (concurrency=${config.senderConcurrency})")
+          Await.result(runIteration(mqSender), 1.minute) // lasts ~ 1 second
         }
 
         logger.info("Sending done, waiting for all messages to be flushed ...")
-        Thread.sleep(3000L)
+        Thread.sleep(3.second.toMillis)
       }
     }.flatMap(_ => mqSender.close())
   }
 
-  private def nextMessagesBatch(): Seq[String] = {
-    (1 to config.batchSizeSend)
+  private def runIteration(mqSender: MqSender): Future[Unit] = {
+    val batchSize = config.batchSizeSend
+    val sentMessages = new AtomicInteger(0)
+    val iterationStart = clock.millis()
+
+    def send(): Future[Unit] = {
+      if (sentMessages.get() >= config.msgsPerSecond) {
+        val iterationEnd = clock.millis()
+        Thread.sleep(math.max(0, 1.second.toMillis - (iterationEnd - iterationStart)))
+        Future.successful(())
+      } else {
+        val sendStart = clock.millis()
+        sentMessages.addAndGet(batchSize)
+        mqSender.send(nextMessagesBatch(batchSize)).flatMap { _ =>
+          LocalMetrics.messageCounter.inc(batchSize.toDouble)
+          LocalMetrics.messageLatencyHistogram.observe((clock.millis() - sendStart).toDouble)
+          send()
+        }
+      }
+    }
+
+    val senderConcurrency = config.senderConcurrency
+    Future
+      .sequence(
+        (1 to senderConcurrency).map { _ => send() }
+      )
+      .map(_ => ())
+  }
+
+  private def nextMessagesBatch(batchSize: Int): Seq[String] = {
+    (1 to batchSize)
       .map(_ => messagesPool.nextMessage())
       .map(Timestamp.add(_, clock))
   }

--- a/clients/kafka/src/main/scala/mqperf/kafka/KafkaMq.scala
+++ b/clients/kafka/src/main/scala/mqperf/kafka/KafkaMq.scala
@@ -1,7 +1,7 @@
 package mqperf.kafka
 
 import com.typesafe.scalalogging.StrictLogging
-import mqperf.{Config, Mq, MqReceiver, MqSender, MqSenderFactory}
+import mqperf.{Config, Mq, MqReceiver, MqReceiverFactory, MqSender, MqSenderFactory}
 import org.apache.kafka.clients.admin.{Admin, NewTopic}
 import org.apache.kafka.clients.consumer.{ConsumerRecord, KafkaConsumer, OffsetAndMetadata}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord, RecordMetadata}
@@ -87,7 +87,7 @@ class KafkaMq(clock: Clock) extends Mq with StrictLogging {
     }
   }
 
-  override def createReceiver(config: Config): MqReceiver = new MqReceiver {
+  override def createReceiverFactory(config: Config): MqReceiverFactory = () => new MqReceiver {
     val hosts: String = config.mqConfig(HostsConfigKey)
     val topic: String = config.mqConfig(TopicConfigKey)
     val groupId: String = config.mqConfig("groupId")

--- a/clients/kafka/src/main/scala/mqperf/kafka/KafkaMq.scala
+++ b/clients/kafka/src/main/scala/mqperf/kafka/KafkaMq.scala
@@ -1,7 +1,7 @@
 package mqperf.kafka
 
 import com.typesafe.scalalogging.StrictLogging
-import mqperf.{Config, Mq, MqReceiver, MqSender}
+import mqperf.{Config, Mq, MqReceiver, MqSender, MqSenderFactory}
 import org.apache.kafka.clients.admin.{Admin, NewTopic}
 import org.apache.kafka.clients.consumer.{ConsumerRecord, KafkaConsumer, OffsetAndMetadata}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord, RecordMetadata}
@@ -59,7 +59,7 @@ class KafkaMq(clock: Clock) extends Mq with StrictLogging {
     }
   }
 
-  override def createSender(config: Config): MqSender = new MqSender {
+  override def createSenderFactory (config: Config): MqSenderFactory = () => new MqSender {
     val hosts: String = config.mqConfig(HostsConfigKey)
     val topic: String = config.mqConfig(TopicConfigKey)
     val acks: String = config.mqConfig("acks")

--- a/docker/scripts/test-kafka.json
+++ b/docker/scripts/test-kafka.json
@@ -6,7 +6,7 @@
   "batchSizeSend": 10,
   "senderConcurrency": 200,
   "batchSizeReceive": 10,
-  "receiverConcurrency": 200,
+  "receiverConcurrency": 8,
   "mqConfig": {
     "hosts": "broker:29092",
     "topic": "mqperf-test-1",

--- a/docker/scripts/test-kafka.json
+++ b/docker/scripts/test-kafka.json
@@ -4,8 +4,10 @@
   "msgsPerProcessInSecond": 10,
   "msgSizeBytes": 1024,
   "batchSizeSend": 10,
+  "sendersNumber": 1,
   "senderConcurrency": 200,
   "batchSizeReceive": 10,
+  "receiversNumber": 1,
   "receiverConcurrency": 8,
   "mqConfig": {
     "hosts": "broker:29092",

--- a/docker/scripts/test-kafka.json
+++ b/docker/scripts/test-kafka.json
@@ -4,9 +4,9 @@
   "msgsPerSecond": 10,
   "msgSizeBytes": 1024,
   "batchSizeSend": 10,
-  "senderConcurrency": 4,
+  "senderConcurrency": 200,
   "batchSizeReceive": 10,
-  "receiverConcurrency": 4,
+  "receiverConcurrency": 200,
   "mqConfig": {
     "hosts": "broker:29092",
     "topic": "mqperf-test-1",

--- a/docker/scripts/test-kafka.json
+++ b/docker/scripts/test-kafka.json
@@ -4,8 +4,9 @@
   "msgsPerSecond": 10,
   "msgSizeBytes": 1024,
   "batchSizeSend": 10,
+  "senderConcurrency": 4,
   "batchSizeReceive": 10,
-  "maxSendInFlight": 10,
+  "receiverConcurrency": 4,
   "mqConfig": {
     "hosts": "broker:29092",
     "topic": "mqperf-test-1",

--- a/docker/scripts/test-kafka.json
+++ b/docker/scripts/test-kafka.json
@@ -1,7 +1,7 @@
 {
   "testId": "test-1",
   "testLengthSeconds": 300,
-  "msgsPerSecond": 10,
+  "msgsPerProcessInSecond": 10,
   "msgSizeBytes": 1024,
   "batchSizeSend": 10,
   "senderConcurrency": 200,

--- a/scripts/test-example-kafka.json
+++ b/scripts/test-example-kafka.json
@@ -1,7 +1,7 @@
 {
   "testId": "test-1",
   "testLengthSeconds": 300,
-  "msgsPerSecond": 100000,
+  "msgsPerProcessInSecond": 1000,
   "msgSizeBytes": 1024,
   "batchSizeSend": 1000,
   "senderConcurrency": 200,

--- a/scripts/test-example-kafka.json
+++ b/scripts/test-example-kafka.json
@@ -4,8 +4,9 @@
   "msgsPerSecond": 100000,
   "msgSizeBytes": 1024,
   "batchSizeSend": 1000,
+  "senderConcurrency": 4,
   "batchSizeReceive": 1000,
-  "maxSendInFlight": 10000,
+  "receiverConcurrency": 4,
   "mqConfig": {
     "hosts": "my-cluster-kafka-bootstrap:9092",
     "topic": "mqperf-test-1",

--- a/scripts/test-example-kafka.json
+++ b/scripts/test-example-kafka.json
@@ -4,9 +4,9 @@
   "msgsPerSecond": 100000,
   "msgSizeBytes": 1024,
   "batchSizeSend": 1000,
-  "senderConcurrency": 4,
+  "senderConcurrency": 200,
   "batchSizeReceive": 1000,
-  "receiverConcurrency": 4,
+  "receiverConcurrency": 200,
   "mqConfig": {
     "hosts": "my-cluster-kafka-bootstrap:9092",
     "topic": "mqperf-test-1",

--- a/scripts/test-example-kafka.json
+++ b/scripts/test-example-kafka.json
@@ -4,8 +4,10 @@
   "msgsPerProcessInSecond": 1000,
   "msgSizeBytes": 1024,
   "batchSizeSend": 1000,
+  "sendersNumber": 1,
   "senderConcurrency": 200,
   "batchSizeReceive": 1000,
+  "receiversNumber": 1,
   "receiverConcurrency": 8,
   "mqConfig": {
     "hosts": "my-cluster-kafka-bootstrap:9092",

--- a/scripts/test-example-kafka.json
+++ b/scripts/test-example-kafka.json
@@ -6,7 +6,7 @@
   "batchSizeSend": 1000,
   "senderConcurrency": 200,
   "batchSizeReceive": 1000,
-  "receiverConcurrency": 200,
+  "receiverConcurrency": 8,
   "mqConfig": {
     "hosts": "my-cluster-kafka-bootstrap:9092",
     "topic": "mqperf-test-1",


### PR DESCRIPTION
Adds new configs: sendersNumber, senderConcurrency, receiversNumber, receiverConcurrency.
Renames config: msgsPerSecond -> msgsPerProcessInSecond.
Removes `maxSendInFligh` config.

A sender node will start `sendersNumber` instances of `mqSenders`. Each `mqSender` will send up to `msgsPerProcessInSecond` messages per concurrent process per second. Number of concurrent processes is equal to `senderConcurrency`. In other words sender node should send up to `sendersNumber * senderConcurrency * msgsPerProcessInSecond` messages, in batches of `batchSizeSend` messages. Each message has `msgSizeBytes` bytes.

A receiver node will start `receiversNumber` instances of `mqReceiver`. Each `mqReceiver` will receive messages in batches of up to `batchSizeReceive`. One receiver receives at most `receiverConcurrency` concurrent batches.